### PR TITLE
[NO-ISSUE] Ensure build before publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guidepup/guidepup",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "screen-reader driver for automation testing",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "gen": "yarn gen:voiceover",
     "gen:voiceover": "ts-node ./src/macOS/VoiceOver/generateClass.ts",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "lint:fix": "yarn lint --fix"
+    "lint:fix": "yarn lint --fix",
+    "prepublish": "yarn build"
   },
   "dependencies": {
     "@jxa/global-type": "^1.3.4",


### PR DESCRIPTION
Missing the build step in the publish pipeline. This introduces the `prepublish` `package.json` command to ensure that the `lib` directory is built before publishing the module to NPM.