### PR TITLE
docs: fix voiceover playwright example

### DIFF
--- a/examples/playwright-voiceover/README.md
+++ b/examples/playwright-voiceover/README.md
@@ -15,10 +15,9 @@ npm run test
 ## Test flow
 
 1. The test launches Safari using Playwright
-2. Navigates to the Playwright website
-3. Moves through the website using VoiceOver controlled by Guidepup to the search input
-4. Searches for Safari
-5. Moves to the Webkit section of the docs
+2. Navigates to the GitHub website
+3. Moves through the website using VoiceOver controlled by Guidepup
+4. Traverses headings until the Guidepup heading in the README.md is found
 
 ## See also
 

--- a/examples/playwright-voiceover/tests/itemTextSnapshot.json
+++ b/examples/playwright-voiceover/tests/itemTextSnapshot.json
@@ -1,0 +1,9 @@
+[
+  "Skip to content link",
+  "guidepup/guidepup heading level 1",
+  "Latest commit heading level 2",
+  "Git stats heading level 2",
+  "Files heading level 2",
+  "README.md heading level 2",
+  "Guidepup heading level 1"
+]

--- a/examples/playwright-voiceover/tests/playwright.spec.ts
+++ b/examples/playwright-voiceover/tests/playwright.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "@playwright/test";
-import searchJourneyItemTextSnapshot from "./searchJourneyItemTextSnapshot.json";
+import itemTextSnapshot from "./itemTextSnapshot.json";
 import test from "./voiceover-test";
 
 function delay(ms: number) {
@@ -21,36 +21,22 @@ async function waitForWebContentAnnouncement(voiceOver) {
 }
 
 test.describe("Playwright VoiceOver", () => {
-  test("I can navigate the Playwright website to the Safari section", async ({
+  test("I can navigate the Guidepup Github page", async ({
     page,
     voiceOver,
   }) => {
-    await page.goto("https://playwright.dev/", {
+    // Navigate to Guidepup GitHub page 🎉
+    await page.goto("https://github.com/guidepup/guidepup", {
       waitUntil: "domcontentloaded",
     });
 
-    // Wait for page to be ready and interact.
-    await expect(page.locator(".navbar__logo")).toBeVisible();
+    // Wait for page to be ready and interact 🙌
+    await expect(page.locator('header[role="banner"]')).toBeVisible();
     await waitForWebContentAnnouncement(voiceOver);
     await voiceOver.interact();
 
-    // Navigate to the search bar.
-    while (!(await voiceOver.lastSpokenPhrase())?.startsWith("Search")) {
-      await voiceOver.perform(voiceOver.keyboard.commands.findNextControl);
-    }
-
-    // Search for Safari.
-    // Comboboxes are fiddly to get right... 😅 Seems with the Playwright
-    // website we need to do some arrow keying to get the required focus
-    // on the desired option.
-    await voiceOver.type("Safari");
-    await voiceOver.press("ArrowDown");
-    await voiceOver.press("ArrowUp");
-    await Promise.all([page.waitForNavigation(), voiceOver.act()]);
-    expect(page.url()).toBe("https://playwright.dev/docs/browsers#webkit");
-
-    // Let's navigate the page to the WebKit section.
-    while ((await voiceOver.itemText()) !== "WebKit heading level 2") {
+    // Move across the page menu to the Guidepup heading using VoiceOver 🔎
+    while ((await voiceOver.itemText()) !== "Guidepup heading level 1") {
       await voiceOver.perform(voiceOver.keyboard.commands.findNextHeading);
     }
 
@@ -58,7 +44,7 @@ test.describe("Playwright VoiceOver", () => {
     // the way there is as expected.
     const itemTextLog = await voiceOver.itemTextLog();
 
-    for (const expectedItem of searchJourneyItemTextSnapshot) {
+    for (const expectedItem of itemTextSnapshot) {
       expect(itemTextLog).toContain(expectedItem);
     }
   });

--- a/examples/playwright-voiceover/tests/searchJourneyItemTextSnapshot.json
+++ b/examples/playwright-voiceover/tests/searchJourneyItemTextSnapshot.json
@@ -1,7 +1,0 @@
-[
-  "🌜 🌞 button",
-  "Browsers heading level 1",
-  "Chromium heading level 2",
-  "Firefox heading level 2",
-  "WebKit heading level 2"
-]


### PR DESCRIPTION
The Playwright website has moved on, and isn't a stable source to be running integration tests against.

Migrated to GitHub where have a degree of control provided care taken with what attempt to interact with. It is fairly likely that GitHub will continue to render the `README.md`, so navigating by headers to a known heading level which is owned by source control should be stable.