### PR TITLE
chore: don't exclude README.md from package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,4 +2,5 @@
 !lib/**
 !LICENSE
 !package.json
+!README.md
 !yarn.lock

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guidepup/guidepup",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Screen-reader driver for automation.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
Currently the `README.md` is being ignored from the package tarball so the NPM page is blank.