### PR TITLE
fix: ensure waiting for not running doesn't restart VoiceOver

### DIFF
--- a/src/macOS/VoiceOver/isRunning.test.ts
+++ b/src/macOS/VoiceOver/isRunning.test.ts
@@ -16,6 +16,10 @@ jest.mock("../runAppleScript", () => ({
 }));
 
 describe("isRunning", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  })
+
   describe.each`
     description          | options
     ${"without options"} | ${undefined}
@@ -108,39 +112,104 @@ describe("isRunning", () => {
         });
       });
 
-      describe("when AppleScript says VoiceOver is running", () => {
-        beforeEach(() => {
-          mockType(runAppleScript).mockResolvedValue("true");
+      describe("when called without a skipActivate argument", () => {
+        describe("when AppleScript says VoiceOver is running", () => {
+          beforeEach(() => {
+            mockType(runAppleScript).mockResolvedValue("true");
+          });
+
+          describe("when attempting to activate VoiceOver throws an error", () => {
+            const errorStub = new Error("test-error");
+
+            beforeEach(async () => {
+              mockType(activate).mockRejectedValue(errorStub);
+
+              result = await isRunning(options);
+            });
+
+            commonProcessAssertions();
+            commonAppleScriptRunningAssertions();
+            commonActivateAssertions();
+
+            it("should return false", () => {
+              expect(result).toBe(false);
+            });
+          });
+
+          describe("when attempting to activate VoiceOver is successful", () => {
+            beforeEach(async () => {
+              mockType(activate).mockResolvedValue();
+
+              result = await isRunning(options);
+            });
+
+            commonProcessAssertions();
+            commonAppleScriptRunningAssertions();
+            commonActivateAssertions();
+
+            it("should return true", () => {
+              expect(result).toBe(true);
+            });
+          });
         });
+      });
 
-        describe("when attempting to activate VoiceOver throws an error", () => {
-          const errorStub = new Error("test-error");
+      describe("when called with skipActivate set to false", () => {
+        describe("when AppleScript says VoiceOver is running", () => {
+          beforeEach(() => {
+            mockType(runAppleScript).mockResolvedValue("true");
+          });
 
+          describe("when attempting to activate VoiceOver throws an error", () => {
+            const errorStub = new Error("test-error");
+
+            beforeEach(async () => {
+              mockType(activate).mockRejectedValue(errorStub);
+
+              result = await isRunning(options, false);
+            });
+
+            commonProcessAssertions();
+            commonAppleScriptRunningAssertions();
+            commonActivateAssertions();
+
+            it("should return false", () => {
+              expect(result).toBe(false);
+            });
+          });
+
+          describe("when attempting to activate VoiceOver is successful", () => {
+            beforeEach(async () => {
+              mockType(activate).mockResolvedValue();
+
+              result = await isRunning(options, false);
+            });
+
+            commonProcessAssertions();
+            commonAppleScriptRunningAssertions();
+            commonActivateAssertions();
+
+            it("should return true", () => {
+              expect(result).toBe(true);
+            });
+          });
+        });
+      });
+
+      describe("when called with skipActivate set to true", () => {
+        describe("when AppleScript says VoiceOver is running", () => {
           beforeEach(async () => {
-            mockType(activate).mockRejectedValue(errorStub);
+            mockType(runAppleScript).mockResolvedValue("true");
 
-            result = await isRunning(options);
+            result = await isRunning(options, true);
           });
 
           commonProcessAssertions();
           commonAppleScriptRunningAssertions();
-          commonActivateAssertions();
 
-          it("should return false", () => {
-            expect(result).toBe(false);
+          it("should not try to activate VoiceOver", () => {
+            expect(activate).not.toHaveBeenCalled();
           });
-        });
-
-        describe("when attempting to activate VoiceOver is successful", () => {
-          beforeEach(async () => {
-            mockType(activate).mockResolvedValue();
-
-            result = await isRunning(options);
-          });
-
-          commonProcessAssertions();
-          commonAppleScriptRunningAssertions();
-          commonActivateAssertions();
 
           it("should return true", () => {
             expect(result).toBe(true);

--- a/src/macOS/VoiceOver/isRunning.ts
+++ b/src/macOS/VoiceOver/isRunning.ts
@@ -4,7 +4,10 @@ import type { CommandOptions } from "../../CommandOptions";
 import { exec } from "child_process";
 import { runAppleScript } from "../runAppleScript";
 
-export async function isRunning(options?: CommandOptions): Promise<boolean> {
+export async function isRunning(
+  options?: CommandOptions,
+  skipActivate = false
+): Promise<boolean> {
   const processRunning = await new Promise<boolean>((resolve) => {
     exec('ps aux | egrep "[V]oiceOver"', (err, stdout) => {
       if (err) {
@@ -25,6 +28,10 @@ export async function isRunning(options?: CommandOptions): Promise<boolean> {
 
   if (appleScriptRunning === "false") {
     return false;
+  }
+
+  if (skipActivate) {
+    return true;
   }
 
   try {

--- a/src/macOS/VoiceOver/waitForNotRunning.test.ts
+++ b/src/macOS/VoiceOver/waitForNotRunning.test.ts
@@ -36,8 +36,8 @@ describe("waitForNotRunning", () => {
         await mockType(waitForCondition).mock.calls[0][0]();
       });
 
-      it("should check whether VoiceOver is not running", () => {
-        expect(isRunning).toHaveBeenCalledWith(options);
+      it("should check whether VoiceOver is not running, making sure to skip the activation check (which would restart VoiceOver!)", () => {
+        expect(isRunning).toHaveBeenCalledWith(options, true);
       });
     });
   });

--- a/src/macOS/VoiceOver/waitForNotRunning.ts
+++ b/src/macOS/VoiceOver/waitForNotRunning.ts
@@ -4,7 +4,7 @@ import { isRunning } from "./isRunning";
 import { waitForCondition } from "../../waitForCondition";
 
 export async function waitForNotRunning(options?: CommandOptions): Promise<void> {
-  return await waitForCondition(async () => !(await isRunning(options)), {
+  return await waitForCondition(async () => !(await isRunning(options, true)), {
     timeoutErrorMessage: ERR_VOICE_OVER_NOT_RUNNING_TIMEOUT,
   });
 }


### PR DESCRIPTION
Seems the `isRunning()` call activates (aka starts if not already running) VoiceOver which isn't ideal for the negative check for is it not running.