### PR TITLE
feat: add screen recording method for windows

### DIFF
--- a/examples/hello-nvda/index.ts
+++ b/examples/hello-nvda/index.ts
@@ -1,4 +1,4 @@
-import { nvda, windowsActivate, windowsQuit } from "../../src";
+import { nvda, windowsActivate, windowsQuit, windowsRecord } from "../../src";
 
 const delay = async (ms: number) =>
   await new Promise((resolve) => setTimeout(resolve, ms));
@@ -7,7 +7,12 @@ const delay = async (ms: number) =>
  * Starts and stops NVDA.
  */
 async function run(): Promise<void> {
+  let stopRecording;
+
   try {
+    // Start the screen recording.
+    stopRecording = windowsRecord(`./recordings/hello-nvda-${+new Date()}.mp4`);
+
     // Start the NVDA screen reader.
     // Set the default to only capture the first page of spoken text per action
     // for speed improvement.
@@ -39,7 +44,11 @@ async function run(): Promise<void> {
     // Ensure we stop NVDA.
     await nvda.stop();
 
+    // Ensure we quit Edge.
     await windowsQuit("msedge.exe");
+
+    // Ensure we stop the recording.
+    stopRecording();
   }
 }
 

--- a/examples/playwright-nvda/tests/chromium/chromium.spec.ts
+++ b/examples/playwright-nvda/tests/chromium/chromium.spec.ts
@@ -2,6 +2,7 @@ import { headerNavigation } from "../headerNavigation";
 import { logIncludesExpectedPhrases } from "../../../logIncludesExpectedPhrases";
 import spokenPhraseSnapshot from "./chromium.spokenPhrase.snapshot.json";
 import { nvdaTest as test } from "../../nvda-test";
+import { windowsRecord } from "../../../../lib";
 
 test.describe("Chromium Playwright NVDA", () => {
   test("I can navigate the Guidepup Github page", async ({
@@ -9,15 +10,25 @@ test.describe("Chromium Playwright NVDA", () => {
     page,
     nvda,
   }) => {
-    await headerNavigation({ browserName, page, nvda });
+    let stopRecording;
 
-    // Assert that we've ended up where we expected and what we were told on
-    // the way there is as expected.
+    try {
+      stopRecording = windowsRecord(
+        `./recordings/playwright-nvda-chromium-${+new Date()}.mp4`
+      );
 
-    const spokenPhraseLog = await nvda.spokenPhraseLog();
+      await headerNavigation({ browserName, page, nvda });
 
-    console.log(JSON.stringify(spokenPhraseLog, undefined, 2));
+      // Assert that we've ended up where we expected and what we were told on
+      // the way there is as expected.
 
-    logIncludesExpectedPhrases(spokenPhraseLog, spokenPhraseSnapshot);
+      const spokenPhraseLog = await nvda.spokenPhraseLog();
+
+      console.log(JSON.stringify(spokenPhraseLog, undefined, 2));
+
+      logIncludesExpectedPhrases(spokenPhraseLog, spokenPhraseSnapshot);
+    } finally {
+      stopRecording();
+    }
   });
 });

--- a/examples/playwright-nvda/tests/firefox/firefox.spec.ts
+++ b/examples/playwright-nvda/tests/firefox/firefox.spec.ts
@@ -2,6 +2,7 @@ import { headerNavigation } from "../headerNavigation";
 import { logIncludesExpectedPhrases } from "../../../logIncludesExpectedPhrases";
 import spokenPhraseSnapshot from "./firefox.spokenPhrase.snapshot.json";
 import { nvdaTest as test } from "../../nvda-test";
+import { windowsRecord } from "../../../../lib";
 
 test.describe("Firefox Playwright NVDA", () => {
   test("I can navigate the Guidepup Github page", async ({
@@ -9,15 +10,24 @@ test.describe("Firefox Playwright NVDA", () => {
     page,
     nvda,
   }) => {
-    await headerNavigation({ browserName, page, nvda });
+    let stopRecording;
 
-    // Assert that we've ended up where we expected and what we were told on
-    // the way there is as expected.
+    try {
+      stopRecording = windowsRecord(
+        `./recordings/playwright-nvda-firefox-${+new Date()}.mp4`
+      );
+      await headerNavigation({ browserName, page, nvda });
 
-    const spokenPhraseLog = await nvda.spokenPhraseLog();
+      // Assert that we've ended up where we expected and what we were told on
+      // the way there is as expected.
 
-    console.log(JSON.stringify(spokenPhraseLog, undefined, 2));
+      const spokenPhraseLog = await nvda.spokenPhraseLog();
 
-    logIncludesExpectedPhrases(spokenPhraseLog, spokenPhraseSnapshot);
+      console.log(JSON.stringify(spokenPhraseLog, undefined, 2));
+
+      logIncludesExpectedPhrases(spokenPhraseLog, spokenPhraseSnapshot);
+    } finally {
+      stopRecording();
+    }
   });
 });

--- a/examples/playwright-voiceover/tests/chromium/chromium.spec.ts
+++ b/examples/playwright-voiceover/tests/chromium/chromium.spec.ts
@@ -10,24 +10,28 @@ test.describe("Chromium Playwright VoiceOver", () => {
     page,
     voiceOver,
   }) => {
-    const stopRecording = macOSRecord(
-      `./recordings/playwright-voiceover-chromium-${+new Date()}.mov`
-    );
+    let stopRecording;
 
-    await headerNavigation({ page, voiceOver });
+    try {
+      stopRecording = macOSRecord(
+        `./recordings/playwright-voiceover-chromium-${+new Date()}.mov`
+      );
 
-    // Assert that we've ended up where we expected and what we were told on
-    // the way there is as expected.
+      await headerNavigation({ page, voiceOver });
 
-    const itemTextLog = await voiceOver.itemTextLog();
-    const spokenPhraseLog = await voiceOver.spokenPhraseLog();
+      // Assert that we've ended up where we expected and what we were told on
+      // the way there is as expected.
 
-    console.log(JSON.stringify(itemTextLog, undefined, 2));
-    console.log(JSON.stringify(spokenPhraseLog, undefined, 2));
+      const itemTextLog = await voiceOver.itemTextLog();
+      const spokenPhraseLog = await voiceOver.spokenPhraseLog();
 
-    logIncludesExpectedPhrases(itemTextLog, itemTextSnapshot);
-    logIncludesExpectedPhrases(spokenPhraseLog, spokenPhraseSnapshot);
+      console.log(JSON.stringify(itemTextLog, undefined, 2));
+      console.log(JSON.stringify(spokenPhraseLog, undefined, 2));
 
-    stopRecording();
+      logIncludesExpectedPhrases(itemTextLog, itemTextSnapshot);
+      logIncludesExpectedPhrases(spokenPhraseLog, spokenPhraseSnapshot);
+    } finally {
+      stopRecording();
+    }
   });
 });

--- a/examples/playwright-voiceover/tests/firefox/firefox.spec.ts
+++ b/examples/playwright-voiceover/tests/firefox/firefox.spec.ts
@@ -10,24 +10,28 @@ test.describe("Firefox Playwright VoiceOver", () => {
     page,
     voiceOver,
   }) => {
-    const stopRecording = macOSRecord(
-      `./recordings/playwright-voiceover-firefox-${+new Date()}.mov`
-    );
+    let stopRecording;
 
-    await headerNavigation({ page, voiceOver });
+    try {
+      stopRecording = macOSRecord(
+        `./recordings/playwright-voiceover-firefox-${+new Date()}.mov`
+      );
 
-    // Assert that we've ended up where we expected and what we were told on
-    // the way there is as expected.
+      await headerNavigation({ page, voiceOver });
 
-    const itemTextLog = await voiceOver.itemTextLog();
-    const spokenPhraseLog = await voiceOver.spokenPhraseLog();
+      // Assert that we've ended up where we expected and what we were told on
+      // the way there is as expected.
 
-    console.log(JSON.stringify(itemTextLog, undefined, 2));
-    console.log(JSON.stringify(spokenPhraseLog, undefined, 2));
+      const itemTextLog = await voiceOver.itemTextLog();
+      const spokenPhraseLog = await voiceOver.spokenPhraseLog();
 
-    logIncludesExpectedPhrases(itemTextLog, itemTextSnapshot);
-    logIncludesExpectedPhrases(spokenPhraseLog, spokenPhraseSnapshot);
+      console.log(JSON.stringify(itemTextLog, undefined, 2));
+      console.log(JSON.stringify(spokenPhraseLog, undefined, 2));
 
-    stopRecording();
+      logIncludesExpectedPhrases(itemTextLog, itemTextSnapshot);
+      logIncludesExpectedPhrases(spokenPhraseLog, spokenPhraseSnapshot);
+    } finally {
+      stopRecording();
+    }
   });
 });

--- a/examples/playwright-voiceover/tests/webkit/webkit.spec.ts
+++ b/examples/playwright-voiceover/tests/webkit/webkit.spec.ts
@@ -10,24 +10,28 @@ test.describe("Webkit Playwright VoiceOver", () => {
     page,
     voiceOver,
   }) => {
-    const stopRecording = macOSRecord(
-      `./recordings/playwright-voiceover-webkit-${+new Date()}.mov`
-    );
+    let stopRecording;
 
-    await headerNavigation({ page, voiceOver });
+    try {
+      stopRecording = macOSRecord(
+        `./recordings/playwright-voiceover-webkit-${+new Date()}.mov`
+      );
 
-    // Assert that we've ended up where we expected and what we were told on
-    // the way there is as expected.
+      await headerNavigation({ page, voiceOver });
 
-    const itemTextLog = await voiceOver.itemTextLog();
-    const spokenPhraseLog = await voiceOver.spokenPhraseLog();
+      // Assert that we've ended up where we expected and what we were told on
+      // the way there is as expected.
 
-    console.log(JSON.stringify(itemTextLog, undefined, 2));
-    console.log(JSON.stringify(spokenPhraseLog, undefined, 2));
+      const itemTextLog = await voiceOver.itemTextLog();
+      const spokenPhraseLog = await voiceOver.spokenPhraseLog();
 
-    logIncludesExpectedPhrases(itemTextLog, itemTextSnapshot);
-    logIncludesExpectedPhrases(spokenPhraseLog, spokenPhraseSnapshot);
+      console.log(JSON.stringify(itemTextLog, undefined, 2));
+      console.log(JSON.stringify(spokenPhraseLog, undefined, 2));
 
-    stopRecording();
+      logIncludesExpectedPhrases(itemTextLog, itemTextSnapshot);
+      logIncludesExpectedPhrases(spokenPhraseLog, spokenPhraseSnapshot);
+    } finally {
+      stopRecording();
+    }
   });
 });

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
+    "ffmpeg-static": "^5.2.0",
     "regedit": "5.0.1",
     "semver": "^7.3.8",
     "shelljs": "^0.8.5"

--- a/src/windows/index.ts
+++ b/src/windows/index.ts
@@ -5,3 +5,4 @@ export type { KeystrokeCommand as WindowsKeystrokeCommand } from "./KeystrokeCom
 export { Modifiers as WindowsModifiers } from "./Modifiers";
 export { activate as windowsActivate } from "./activate";
 export { quit as windowsQuit } from "./quit";
+export { record as windowsRecord } from "./record";

--- a/src/windows/record.test.ts
+++ b/src/windows/record.test.ts
@@ -1,0 +1,62 @@
+import { ChildProcess, spawn } from "child_process";
+import { mkdirSync, unlinkSync } from "fs";
+import { join } from "path";
+import { record } from "./record";
+
+jest.mock("ffmpeg-static", () => "test-ffmpeg");
+jest.mock("child_process", () => ({
+  spawn: jest.fn(),
+}));
+jest.mock("fs", () => ({
+  mkdirSync: jest.fn(),
+  unlinkSync: jest.fn(),
+}));
+
+const mockDirectory = "test-directory";
+const mockFilepath = join(mockDirectory, "test-filepath.ext");
+
+const mockProcess = {
+  stdin: {
+    write: jest.fn(),
+  },
+};
+
+describe("record", () => {
+  let stopRecording;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(spawn).mockReturnValue(mockProcess as unknown as ChildProcess);
+
+    stopRecording = record(mockFilepath);
+  });
+
+  it("should create the directory path", () => {
+    expect(mkdirSync).toHaveBeenCalledWith(mockDirectory, { recursive: true });
+  });
+
+  it("should delete the file if already exists (to eliminate dealing with overwrite options)", () => {
+    expect(unlinkSync).toHaveBeenCalledWith(mockFilepath);
+  });
+
+  it("should spawn an ffmpeg child process for recording", () => {
+    expect(spawn).toHaveBeenCalledWith("test-ffmpeg", [
+      "-f",
+      "gdigrab",
+      "-framerate",
+      "60",
+      "-i",
+      "desktop",
+      "-vcodec",
+      "mpeg4",
+      mockFilepath,
+    ]);
+  });
+
+  it("should return a function to stop the ffmpeg process", () => {
+    stopRecording();
+
+    expect(mockProcess.stdin.write).toHaveBeenCalledWith("q");
+  });
+});

--- a/src/windows/record.ts
+++ b/src/windows/record.ts
@@ -1,0 +1,38 @@
+import { mkdirSync, unlinkSync } from "fs";
+import { dirname } from "path";
+import { spawn } from "child_process";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const ffmpegPath = require("ffmpeg-static");
+
+/**
+ * Start a screen recording.
+ *
+ * @param {string} filepath The file path to save the screen recording to.
+ * @returns {Function} A function to stop the screen recording.
+ */
+export function record(filepath: string): () => void {
+  mkdirSync(dirname(filepath), { recursive: true });
+
+  try {
+    unlinkSync(filepath);
+  } catch (_) {
+    // file doesn't exist.
+  }
+
+  const screencapture = spawn(ffmpegPath, [
+    "-f",
+    "gdigrab",
+    "-framerate",
+    "60",
+    "-i",
+    "desktop",
+    "-vcodec",
+    "mpeg4",
+    filepath,
+  ]);
+
+  return () => {
+    screencapture.stdin.write("q");
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,6 +309,16 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@derhuerst/http-basic@^8.2.0":
+  version "8.2.4"
+  resolved "https://registry.yarnpkg.com/@derhuerst/http-basic/-/http-basic-8.2.4.tgz#d021ebb8f65d54bea681ae6f4a8733ce89e7f59b"
+  integrity sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==
+  dependencies:
+    caseless "^0.12.0"
+    concat-stream "^2.0.0"
+    http-response-object "^3.0.1"
+    parse-cache-control "^1.0.1"
+
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -767,6 +777,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.7.1.tgz#06d732ead0bd5ad978ef0ea9cbdeb24dc8717514"
   integrity sha512-LT+OIXpp2kj4E2S/p91BMe+VgGX2+lfO+XTpfXhh+bCk2LkQtHZSub8ewFBMGP5ClysPjTDFa4sMI8Q3n4T0wg==
 
+"@types/node@^10.0.3":
+  version "10.17.60"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
+  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
+
 "@types/semver@^7.5.0":
   version "7.5.3"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.3.tgz#9a726e116beb26c24f1ccd6850201e1246122e04"
@@ -893,6 +908,13 @@ acorn@^8.9.0:
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
+
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 ajv@^6.12.4:
   version "6.12.6"
@@ -1116,6 +1138,11 @@ caniuse-lite@^1.0.30001539:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001541.tgz#b1aef0fadd87fb72db4dcb55d220eae17b81cdb1"
   integrity sha512-bLOsqxDgTqUBkzxbNlSBt8annkDpQB9NdzdTbO2ooJ+eC/IQcvDspDc058g84ejCelF7vHUx57KIOjEecOHXaw==
 
+caseless@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+  integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
+
 chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -1196,6 +1223,16 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
+concat-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-2.0.0.tgz#414cf5af790a48c60ab9be4527d56d5e41133cb1"
+  integrity sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.0.2"
+    typedarray "^0.0.6"
+
 convert-source-map@^1.6.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
@@ -1238,7 +1275,7 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -1313,6 +1350,11 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+env-paths@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
+  integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -1511,6 +1553,16 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+ffmpeg-static@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ffmpeg-static/-/ffmpeg-static-5.2.0.tgz#6ca64a5ed6e69ec4896d175c1f69dd575db7c5ef"
+  integrity sha512-WrM7kLW+do9HLr+H6tk7LzQ7kPqbAgLjdzNE32+u3Ff11gXt9Kkkd2nusGFrlWMIe+XaA97t+I8JS7sZIrvRgA==
+  dependencies:
+    "@derhuerst/http-basic" "^8.2.0"
+    env-paths "^2.2.0"
+    https-proxy-agent "^5.0.0"
+    progress "^2.0.3"
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -1703,6 +1755,21 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
+http-response-object@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/http-response-object/-/http-response-object-3.0.2.tgz#7f435bb210454e4360d074ef1f989d5ea8aa9810"
+  integrity sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==
+  dependencies:
+    "@types/node" "^10.0.3"
+
+https-proxy-agent@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
@@ -1747,7 +1814,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@~2.0.1:
+inherits@2, inherits@^2.0.3, inherits@~2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2572,6 +2639,11 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-cache-control@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-cache-control/-/parse-cache-control-1.0.1.tgz#8eeab3e54fa56920fe16ba38f77fa21aacc2d74e"
+  integrity sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==
+
 parse-json@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
@@ -2651,6 +2723,11 @@ pretty-format@^29.0.0, pretty-format@^29.7.0:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
+progress@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 prompts@^2.0.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
@@ -2693,6 +2770,15 @@ react-is@^18.0.0:
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
+
+readable-stream@^3.0.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 rechoir@^0.6.2:
   version "0.6.2"
@@ -2781,6 +2867,11 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
@@ -2907,6 +2998,13 @@ string-width@^5.0.1, string-width@^5.1.2:
     eastasianwidth "^0.2.0"
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 string_decoder@~0.10.x:
   version "0.10.31"
@@ -3067,6 +3165,11 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
+typedarray@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+  integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
+
 typedoc@^0.25.1:
   version "0.25.1"
   resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.25.1.tgz#50de2d8fb93623fbfb59e2fa6407ff40e3d3f438"
@@ -3096,6 +3199,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Adds a `windowsRecord` export for screen capture on windows, mirroring the existing `macOSRecord` method.

Currently using ffmpeg in absence of obvious/easy Windows native way to screen capture.