### PR TITLE
fix: ffmpeg encoding

### DIFF
--- a/src/windows/record.test.ts
+++ b/src/windows/record.test.ts
@@ -48,6 +48,8 @@ describe("record", () => {
       "60",
       "-i",
       "desktop",
+      "-pix_fmt",
+      "yuv420p",
       "-vcodec",
       "mpeg4",
       mockFilepath,

--- a/src/windows/record.ts
+++ b/src/windows/record.ts
@@ -27,6 +27,8 @@ export function record(filepath: string): () => void {
     "60",
     "-i",
     "desktop",
+    "-pix_fmt",
+    "yuv420p",
     "-vcodec",
     "mpeg4",
     filepath,


### PR DESCRIPTION
MP4 videos produced by Guidepup on Windows aren't working in Quicktime etc.