### PR TITLE
docs: update circleci example

### DIFF
--- a/examples/circleci-voiceover/config.yml
+++ b/examples/circleci-voiceover/config.yml
@@ -1,17 +1,18 @@
 version: 2.1
 
 orbs:
-  macos: circleci/macos@2.0.1
+  macos: circleci/macos@2.5.2
 
 jobs:
   voiceover:
     macos:
-      xcode: 12.5.1
-    resource_class: medium
+      xcode: 15.4.0
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - macos/add-uitest-permissions
       - macos/add-safari-permissions
+      - macos/add-voiceover-permissions
       - run:
           name: Enable VoiceOver Automation
           command: npx @guidepup/setup --ci


### PR DESCRIPTION
# Issue

Fixes #85 

## Details
The circleCI example uses a resource that has been removed[1] so it doesn't work. The orb is a bit old now so bumped that too. There's also a new command for voiceover-permissions which we can use

[1]: https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718

## CheckList

- [x] Has been tested (where required).
