### PR TITLE
refactor: updating GH actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,5 +67,5 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       continue-on-error: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/playwright-nvda.yml
+++ b/.github/workflows/playwright-nvda.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-2025]
         browser: [chromium, firefox]
     steps:
       - uses: actions/checkout@v4
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: Guidepup Setup
-        uses: guidepup/setup-action@0.17.2
+        uses: guidepup/setup-action@0.17.3
         with:
           record: true
       - run: yarn install --frozen-lockfile
@@ -30,7 +30,7 @@ jobs:
         if: always()
         continue-on-error: true
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.os }}-${{ matrix.browser }}
           path: |
             **/test-results/**/*
             **/recordings/**/*

--- a/.github/workflows/playwright-nvda.yml
+++ b/.github/workflows/playwright-nvda.yml
@@ -26,7 +26,7 @@ jobs:
       - run: yarn --cwd ./examples/playwright-nvda install --frozen-lockfile
       - run: yarn --cwd ./examples/playwright-nvda pretest
       - run: yarn --cwd ./examples/playwright-nvda test:${{ matrix.browser }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         continue-on-error: true
         with:

--- a/.github/workflows/playwright-nvda.yml
+++ b/.github/workflows/playwright-nvda.yml
@@ -14,10 +14,10 @@ jobs:
         os: [windows-2019, windows-2022]
         browser: [chromium, firefox]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
       - name: Guidepup Setup
         uses: guidepup/setup-action@0.17.2
         with:

--- a/.github/workflows/playwright-voiceover.yml
+++ b/.github/workflows/playwright-voiceover.yml
@@ -26,7 +26,7 @@ jobs:
       - run: yarn --cwd ./examples/playwright-voiceover install --frozen-lockfile
       - run: yarn --cwd ./examples/playwright-voiceover pretest
       - run: yarn --cwd ./examples/playwright-voiceover test:${{ matrix.browser }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         continue-on-error: true
         with:

--- a/.github/workflows/playwright-voiceover.yml
+++ b/.github/workflows/playwright-voiceover.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: Guidepup Setup
-        uses: guidepup/setup-action@0.17.2
+        uses: guidepup/setup-action@0.17.3
         with:
           record: true
       - run: yarn install --frozen-lockfile
@@ -30,7 +30,7 @@ jobs:
         if: always()
         continue-on-error: true
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.os }}-${{ matrix.browser }}
           path: |
             **/test-results/**/*
             **/recordings/**/*

--- a/.github/workflows/playwright-voiceover.yml
+++ b/.github/workflows/playwright-voiceover.yml
@@ -14,10 +14,10 @@ jobs:
         os: [macos-12, macos-13, macos-14]
         browser: [chromium, firefox, webkit]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
       - name: Guidepup Setup
         uses: guidepup/setup-action@0.17.2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org/
           always-auth: true
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
       - run: yarn install --frozen-lockfile
       - run: yarn ci

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Windows 10 Support](https://img.shields.io/badge/windows-10-blue.svg?logo=windows10)](https://www.microsoft.com/en-gb/software-download/windows10ISO)
 [![Windows Server 2019 Support](https://img.shields.io/badge/windows_server-2019-blue.svg?logo=windows)](https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2019)
 [![Windows Server 2022 Support](https://img.shields.io/badge/windows_server-2022-blue.svg?logo=windows)](https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2022)
+[![Windows Server 2025 Support](https://img.shields.io/badge/windows_server-2025-blue.svg?logo=windows)](https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2025)
 
 Guidepup is a screen reader driver for test automation.
 

--- a/examples/github-actions-voiceover/test.yml
+++ b/examples/github-actions-voiceover/test.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: Enable VoiceOver Automation
-        uses: guidepup/setup-action@0.17.2
+        uses: guidepup/setup-action@0.17.3
 
       # Uncomment and add your steps for your Guidepup tests here
       # - name: Install Dependencies

--- a/examples/github-actions-voiceover/test.yml
+++ b/examples/github-actions-voiceover/test.yml
@@ -14,7 +14,7 @@ jobs:
         os: [macos-12, macos-13, macos-14]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Enable VoiceOver Automation

--- a/examples/github-actions-voiceover/test.yml
+++ b/examples/github-actions-voiceover/test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [macos-12, macos-13, macos-14]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc

--- a/examples/github-actions-voiceover/test.yml
+++ b/examples/github-actions-voiceover/test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
       - name: Enable VoiceOver Automation
         uses: guidepup/setup-action@0.17.2
 


### PR DESCRIPTION
# Issue

~Fixes #<issue_number>.~

## Details

Prevent the pipeline throwing an error:

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

in general updated the following standard actions:
- [actions/setup-node](https://github.com/actions/setup-node/releases/tag/v4.0.0)
  - ✅ update to node 20
- [actions/checkout](https://github.com/actions/checkout/blob/main/CHANGELOG.md#v400)
  - ✅ update to node 20
- [actions/upload-artifact](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)
  - [Multiple uploads to the same named Artifact](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact)
  - [Overwriting an Artifact](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#overwriting-an-artifact)
  - [Merging multiple artifacts](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#merging-multiple-artifacts)
  - [Hidden files](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#hidden-files)

Plus we could [target for the node version defined in `.nvmrc`](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file) directly.

## CheckList

- [ ] ~Has been tested (where required).~