### PR TITLE
fix: prevent VO commands after stop is initiated

### DIFF
--- a/.github/workflows/playwright-voiceover.yml
+++ b/.github/workflows/playwright-voiceover.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-14, macos-15, macos-15-intel, macos-26, macos-26-intel]
+        os: [macos-14, macos-15, macos-26]
         browser: [chromium, firefox, webkit]
     steps:
       - uses: actions/checkout@v6

--- a/examples/github-actions-voiceover/test.yml
+++ b/examples/github-actions-voiceover/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-14, macos-15, macos-15-intel, macos-26, macos-26-intel]
+        os: [macos-14, macos-15, macos-26]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/examples/playwright-voiceover/voiceover-test.ts
+++ b/examples/playwright-voiceover/voiceover-test.ts
@@ -1,6 +1,6 @@
-import { macOSActivate, voiceOver } from "../../lib";
+import { macOSActivate, MacOSKeyCodes, voiceOver } from "../../src";
 import { test } from "@playwright/test";
-import type { VoiceOver } from "../../lib";
+import type { VoiceOver } from "../../src";
 
 const applicationNameMap = {
   chromium: "Google Chrome For Testing",
@@ -43,34 +43,46 @@ const voTest = test.extend<{ voiceOver: VoiceOverPlaywright }>({
         throw new Error(`Browser ${browserName} is not installed.`);
       }
 
-      voiceOverPlaywright.navigateToWebContent = async () => {
+      voiceOverPlaywright.navigateToWebContent = async (
+        clearLogs: boolean = true,
+      ) => {
         await macOSActivate(applicationName);
+
+        await voiceOverPlaywright.perform({ keyCode: MacOSKeyCodes.Control });
 
         await page.bringToFront();
         await page.locator("body").waitFor();
-        await page.locator("body").focus();
-        await page.locator("body").click();
+
+        await voiceOverPlaywright.perform(
+          voiceOverPlaywright.keyboardCommands.openWebItemRotor,
+        );
+
+        await voiceOverPlaywright.type("content");
+
+        await voiceOverPlaywright.perform({ keyCode: MacOSKeyCodes.Enter });
 
         await voiceOverPlaywright.interact();
-
-        await voiceOverPlaywright.perform(
-          voiceOverPlaywright.keyboardCommands.findPreviousHeading,
-        );
-
-        await voiceOverPlaywright.perform(
-          voiceOverPlaywright.keyboardCommands.findPreviousPlainText,
-        );
 
         await voiceOverPlaywright.perform(
           voiceOverPlaywright.keyboardCommands.moveToBeginningOfText,
         );
 
-        await voiceOverPlaywright.clearItemTextLog();
-        await voiceOverPlaywright.clearSpokenPhraseLog();
+        await voiceOverPlaywright.perform({ keyCode: MacOSKeyCodes.Control });
+
+        if (clearLogs) {
+          await voiceOverPlaywright.clearItemTextLog();
+          await voiceOverPlaywright.clearSpokenPhraseLog();
+        }
       };
 
       await voiceOverPlaywright.start({ capture: "initial" });
-      await macOSActivate(applicationNameMap[browserName]);
+      await macOSActivate(applicationName);
+
+      await voiceOverPlaywright.perform(
+        { keyCode: MacOSKeyCodes.Control },
+        { capture: false },
+      );
+
       await use(voiceOverPlaywright);
     } finally {
       try {

--- a/jest.config.js
+++ b/jest.config.js
@@ -32,8 +32,8 @@ module.exports = {
     "<rootDir>/src/macOS/VoiceOver/constants.ts",
     "<rootDir>/src/macOS/VoiceOver/Containments.ts",
     "<rootDir>/src/macOS/VoiceOver/Directions.ts",
-    // TODO: flesh out LogStore tests
-    "<rootDir>/src/macOS/VoiceOver/LogStore.ts",
+    // TODO: flesh out VoiceOverClient tests
+    "<rootDir>/src/macOS/VoiceOver/VoiceOverClient.ts",
     "<rootDir>/src/macOS/VoiceOver/Places.ts",
     "<rootDir>/src/windows/NVDA/keyCodeCommands.ts",
     "<rootDir>/src/windows/NVDA/NVDA.ts",

--- a/src/macOS/VoiceOver/VoiceOver.test.ts
+++ b/src/macOS/VoiceOver/VoiceOver.test.ts
@@ -11,11 +11,11 @@ import {
 import { CommanderCommands } from "./CommanderCommands";
 import { isKeyboard } from "../../isKeyboard";
 import { isMacOS } from "../isMacOS";
-import { LogStore } from "./LogStore";
 import { start } from "./start";
 import { terminateVoiceOverProcess } from "./terminateVoiceOverProcess";
 import { VoiceOver } from "./VoiceOver";
 import { VoiceOverCaption } from "./VoiceOverCaption";
+import { VoiceOverClient } from "./VoiceOverClient";
 import { VoiceOverCommander } from "./VoiceOverCommander";
 import { VoiceOverCursor } from "./VoiceOverCursor";
 import { VoiceOverKeyboard } from "./VoiceOverKeyboard";
@@ -36,8 +36,8 @@ jest.mock("../../isKeyboard", () => ({
 jest.mock("../isMacOS", () => ({
   isMacOS: jest.fn(),
 }));
-jest.mock("./LogStore", () => ({
-  LogStore: jest.fn(),
+jest.mock("./VoiceOverClient", () => ({
+  VoiceOverClient: jest.fn(),
 }));
 jest.mock("./terminateVoiceOverProcess", () => ({
   terminateVoiceOverProcess: jest.fn(),
@@ -66,6 +66,10 @@ jest.mock("./waitForNotRunning", () => ({
 jest.mock("./waitForRunning", () => ({
   waitForRunning: jest.fn(),
 }));
+
+const VoiceOverClientStub = {
+  stop: jest.fn(),
+};
 
 const VoiceOverCaptionStub = {
   lastSpokenPhrase: jest.fn(),
@@ -104,12 +108,16 @@ const VoiceOverMouseStub = {
 };
 
 describe("VoiceOver", () => {
-  let vo, result;
+  let vo: VoiceOver;
+  let result: unknown;
 
   beforeEach(() => {
     jest.resetAllMocks();
     jest.clearAllMocks();
 
+    (VoiceOverClient as jest.Mock<VoiceOverClient>).mockImplementation(
+      () => VoiceOverClientStub as unknown as VoiceOverClient,
+    );
     (VoiceOverCaption as jest.Mock<VoiceOverCaption>).mockImplementation(
       () => VoiceOverCaptionStub as unknown as VoiceOverCaption,
     );
@@ -224,28 +232,28 @@ describe("VoiceOver", () => {
           await vo.start(options);
         });
 
-        it("should construct a log store instance", () => {
-          expect(LogStore).toHaveBeenCalledWith(options);
+        it("should construct a VoiceOver Client instance", () => {
+          expect(VoiceOverClient).toHaveBeenCalledWith(options);
         });
 
         it("should construct a caption instance", () => {
-          expect(VoiceOverCaption).toHaveBeenCalledWith(expect.any(LogStore));
+          expect(VoiceOverCaption).toHaveBeenCalledWith(VoiceOverClientStub);
         });
 
         it("should construct a commander instance", () => {
-          expect(VoiceOverCommander).toHaveBeenCalledWith(expect.any(LogStore));
+          expect(VoiceOverCommander).toHaveBeenCalledWith(VoiceOverClientStub);
         });
 
         it("should construct a cursor instance", () => {
-          expect(VoiceOverCursor).toHaveBeenCalledWith(expect.any(LogStore));
+          expect(VoiceOverCursor).toHaveBeenCalledWith(VoiceOverClientStub);
         });
 
         it("should construct a keyboard instance", () => {
-          expect(VoiceOverKeyboard).toHaveBeenCalledWith(expect.any(LogStore));
+          expect(VoiceOverKeyboard).toHaveBeenCalledWith(VoiceOverClientStub);
         });
 
         it("should construct a mouse instance", () => {
-          expect(VoiceOverMouse).toHaveBeenCalledWith(expect.any(LogStore));
+          expect(VoiceOverMouse).toHaveBeenCalledWith(VoiceOverClientStub);
         });
 
         it("should expose a getter for keyboard commands", () => {
@@ -489,7 +497,7 @@ describe("VoiceOver", () => {
   describe("press", () => {
     describe("when VoiceOver is not running", () => {
       it("should throw an error", async () => {
-        await expect(async () => await vo.press()).rejects.toThrow(
+        await expect(async () => await vo.press("test-key")).rejects.toThrow(
           ERR_VOICE_OVER_NOT_RUNNING,
         );
       });
@@ -517,7 +525,7 @@ describe("VoiceOver", () => {
   describe("type", () => {
     describe("when VoiceOver is not running", () => {
       it("should throw an error", async () => {
-        await expect(async () => await vo.type()).rejects.toThrow(
+        await expect(async () => await vo.type("test-text")).rejects.toThrow(
           ERR_VOICE_OVER_NOT_RUNNING,
         );
       });
@@ -545,9 +553,9 @@ describe("VoiceOver", () => {
   describe("perform", () => {
     describe("when VoiceOver is not running", () => {
       it("should throw an error", async () => {
-        await expect(async () => await vo.perform()).rejects.toThrow(
-          ERR_VOICE_OVER_NOT_RUNNING,
-        );
+        await expect(
+          async () => await vo.perform({ keyCode: 0 }),
+        ).rejects.toThrow(ERR_VOICE_OVER_NOT_RUNNING);
       });
     });
 

--- a/src/macOS/VoiceOver/VoiceOver.ts
+++ b/src/macOS/VoiceOver/VoiceOver.ts
@@ -5,7 +5,6 @@ import {
 } from "./configureSettings";
 import {
   ERR_VOICE_OVER_ALREADY_RUNNING,
-  ERR_VOICE_OVER_CANNOT_BE_STARTED_AS_STOPPING,
   ERR_VOICE_OVER_NOT_RUNNING,
   ERR_VOICE_OVER_NOT_SUPPORTED,
 } from "../errors";
@@ -216,10 +215,6 @@ export class VoiceOver implements ScreenReader {
   async start(options?: CommandOptions): Promise<void> {
     if (!(await this.detect())) {
       throw new Error(ERR_VOICE_OVER_NOT_SUPPORTED);
-    }
-
-    if (this.#stopping) {
-      throw new Error(ERR_VOICE_OVER_CANNOT_BE_STARTED_AS_STOPPING);
     }
 
     if (this.#started) {

--- a/src/macOS/VoiceOver/VoiceOver.ts
+++ b/src/macOS/VoiceOver/VoiceOver.ts
@@ -273,9 +273,9 @@ export class VoiceOver implements ScreenReader {
     }
 
     this.#stopping = true;
-    await this.#client.stop();
 
-    await terminateVoiceOverProcess();
+    await this.#client.stop();
+    await terminateVoiceOverProcess(options);
     await waitForNotRunning(options);
 
     this.#client = null;

--- a/src/macOS/VoiceOver/VoiceOver.ts
+++ b/src/macOS/VoiceOver/VoiceOver.ts
@@ -5,6 +5,7 @@ import {
 } from "./configureSettings";
 import {
   ERR_VOICE_OVER_ALREADY_RUNNING,
+  ERR_VOICE_OVER_CANNOT_BE_STARTED_AS_STOPPING,
   ERR_VOICE_OVER_NOT_RUNNING,
   ERR_VOICE_OVER_NOT_SUPPORTED,
 } from "../errors";
@@ -15,12 +16,12 @@ import { isKeyboard } from "../../isKeyboard";
 import { isMacOS } from "../isMacOS";
 import { KeyboardCommand } from "../KeyboardCommand";
 import { KeyboardOptions } from "../../KeyboardOptions";
-import { LogStore } from "./LogStore";
 import type { Prettify } from "../../typeHelpers";
 import type { ScreenReader } from "../../ScreenReader";
 import { start } from "./start";
 import { terminateVoiceOverProcess } from "./terminateVoiceOverProcess";
 import { VoiceOverCaption } from "./VoiceOverCaption";
+import { VoiceOverClient } from "./VoiceOverClient";
 import { VoiceOverCommander } from "./VoiceOverCommander";
 import { VoiceOverCursor } from "./VoiceOverCursor";
 import { VoiceOverKeyboard } from "./VoiceOverKeyboard";
@@ -43,6 +44,16 @@ export class VoiceOver implements ScreenReader {
    * VoiceOver running status.
    */
   #started = false;
+
+  /**
+   * VoiceOver stopping status.
+   */
+  #stopping = false;
+
+  /**
+   * VoiceOver client for queued execution and log tapping.
+   */
+  #client!: VoiceOverClient;
 
   /**
    * VoiceOver caption APIs.
@@ -92,7 +103,7 @@ export class VoiceOver implements ScreenReader {
    * ```
    */
   get keyboardCommands() {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -124,7 +135,7 @@ export class VoiceOver implements ScreenReader {
    * ```
    */
   get commanderCommands() {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -207,16 +218,20 @@ export class VoiceOver implements ScreenReader {
       throw new Error(ERR_VOICE_OVER_NOT_SUPPORTED);
     }
 
+    if (this.#stopping) {
+      throw new Error(ERR_VOICE_OVER_CANNOT_BE_STARTED_AS_STOPPING);
+    }
+
     if (this.#started) {
       throw new Error(ERR_VOICE_OVER_ALREADY_RUNNING);
     }
 
-    const logStore = new LogStore(options);
-    this.#caption = new VoiceOverCaption(logStore);
-    this.#commander = new VoiceOverCommander(logStore);
-    this.#cursor = new VoiceOverCursor(logStore);
-    this.#keyboard = new VoiceOverKeyboard(logStore);
-    this.#mouse = new VoiceOverMouse(logStore);
+    this.#client = new VoiceOverClient(options);
+    this.#caption = new VoiceOverCaption(this.#client);
+    this.#commander = new VoiceOverCommander(this.#client);
+    this.#cursor = new VoiceOverCursor(this.#client);
+    this.#keyboard = new VoiceOverKeyboard(this.#client);
+    this.#mouse = new VoiceOverMouse(this.#client);
 
     // TODO: handle failures in the following steps more gracefully, we should
     // look to gracefully reset back to default if fail to start rather than
@@ -253,13 +268,17 @@ export class VoiceOver implements ScreenReader {
    * @param {object} [options] Additional options.
    */
   async stop(options?: CommandOptionsWithoutCapture): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
+
+    this.#stopping = true;
+    await this.#client.stop();
 
     await terminateVoiceOverProcess();
     await waitForNotRunning(options);
 
+    this.#client = null;
     this.#caption = null;
     this.#commander = null;
     this.#cursor = null;
@@ -272,6 +291,7 @@ export class VoiceOver implements ScreenReader {
     }
 
     this.#started = false;
+    this.#stopping = false;
   }
 
   /**
@@ -299,7 +319,7 @@ export class VoiceOver implements ScreenReader {
    * @param {object} [options] Additional options.
    */
   async previous(options?: CommandOptions): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -331,7 +351,7 @@ export class VoiceOver implements ScreenReader {
    * @param {object} [options] Additional options.
    */
   async next(options?: CommandOptions): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -366,7 +386,7 @@ export class VoiceOver implements ScreenReader {
    * @param {object} [options] Additional options.
    */
   async act(options?: CommandOptions): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -401,7 +421,7 @@ export class VoiceOver implements ScreenReader {
    * @param {object} [options] Additional options.
    */
   async interact(options?: CommandOptions): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -438,7 +458,7 @@ export class VoiceOver implements ScreenReader {
    * @param {object} [options] Additional options.
    */
   async stopInteracting(options?: CommandOptions): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -475,7 +495,7 @@ export class VoiceOver implements ScreenReader {
    * @returns {Promise<string>} The path to the screenshot file.
    */
   async takeCursorScreenshot(options?: CommandOptions): Promise<string> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -527,7 +547,7 @@ export class VoiceOver implements ScreenReader {
    * @param {object} [options] Additional options.
    */
   async press(key: string, options?: KeyboardOptions): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -561,7 +581,7 @@ export class VoiceOver implements ScreenReader {
    * @param {object} [options] Additional options.
    */
   async type(text: string, options?: KeyboardOptions): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -605,7 +625,7 @@ export class VoiceOver implements ScreenReader {
     command: KeyboardCommand | CommanderCommands,
     options?: CommandOptions,
   ): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -645,7 +665,7 @@ export class VoiceOver implements ScreenReader {
    * @param {object} [options] Click options.
    */
   async click(options?: ClickOptions): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -682,7 +702,7 @@ export class VoiceOver implements ScreenReader {
    * @param {object} [options] Additional options.
    */
   async copyLastSpokenPhrase(options?: CommandOptions): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -719,7 +739,7 @@ export class VoiceOver implements ScreenReader {
    * @param {object} [options] Additional options.
    */
   async saveLastSpokenPhrase(options?: CommandOptions): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -753,7 +773,7 @@ export class VoiceOver implements ScreenReader {
    * @returns {Promise<string>} The last spoken phrase.
    */
   async lastSpokenPhrase(): Promise<string> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -790,7 +810,7 @@ export class VoiceOver implements ScreenReader {
    * @returns {Promise<string>} The item's text.
    */
   async itemText(): Promise<string> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -826,7 +846,7 @@ export class VoiceOver implements ScreenReader {
    * @returns {Promise<string[]>} The spoken phrase log.
    */
   async spokenPhraseLog(): Promise<string[]> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -856,7 +876,7 @@ export class VoiceOver implements ScreenReader {
    * ```
    */
   async clearSpokenPhraseLog(): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -894,7 +914,7 @@ export class VoiceOver implements ScreenReader {
    * @returns {Promise<string[]>} The item text log.
    */
   async itemTextLog(): Promise<string[]> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -926,7 +946,7 @@ export class VoiceOver implements ScreenReader {
    * ```
    */
   async clearItemTextLog(): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 

--- a/src/macOS/VoiceOver/VoiceOverCaption.test.ts
+++ b/src/macOS/VoiceOver/VoiceOverCaption.test.ts
@@ -1,13 +1,13 @@
 import { copyLastSpokenPhrase } from "./copyLastSpokenPhrase";
-import { LogStore } from "./LogStore";
 import { saveLastSpokenPhrase } from "./saveLastSpokenPhrase";
 import { VoiceOverCaption } from "./VoiceOverCaption";
+import { VoiceOverClient } from "./VoiceOverClient";
 
 jest.mock("./copyLastSpokenPhrase", () => ({
   copyLastSpokenPhrase: jest.fn(),
 }));
-jest.mock("./LogStore", () => ({
-  LogStore: jest.fn(),
+jest.mock("./VoiceOverClient", () => ({
+  VoiceOverClient: jest.fn(),
 }));
 jest.mock("./saveLastSpokenPhrase", () => ({
   saveLastSpokenPhrase: jest.fn(),
@@ -18,8 +18,8 @@ const itemTextDummy = "test-item-text";
 
 describe("VoiceOverCaption", () => {
   let caption: VoiceOverCaption;
-  let result;
-  let logStoreDummy: LogStore;
+  let result: unknown;
+  let voiceOverClientDummy: VoiceOverClient;
   let spokenPhraseLogCleared: boolean;
   let itemTextLogCleared: boolean;
 
@@ -30,7 +30,7 @@ describe("VoiceOverCaption", () => {
     itemTextLogCleared = false;
     spokenPhraseLogCleared = false;
 
-    logStoreDummy = {
+    voiceOverClientDummy = {
       async itemText() {
         return itemTextDummy;
       },
@@ -49,9 +49,9 @@ describe("VoiceOverCaption", () => {
       async clearSpokenPhraseLog() {
         spokenPhraseLogCleared = true;
       },
-    } as LogStore;
+    } as VoiceOverClient;
 
-    caption = new VoiceOverCaption(logStoreDummy);
+    caption = new VoiceOverCaption(voiceOverClientDummy);
     result = undefined;
   });
 
@@ -100,7 +100,7 @@ describe("VoiceOverCaption", () => {
   describe("spokenPhraseLog", () => {
     it("should get a log of the spoken phrases", () => {
       expect(caption.spokenPhraseLog()).toEqual(
-        logStoreDummy.spokenPhraseLog()
+        voiceOverClientDummy.spokenPhraseLog(),
       );
     });
   });
@@ -125,7 +125,7 @@ describe("VoiceOverCaption", () => {
 
   describe("itemTextLog", () => {
     it("should get a log of the item text", () => {
-      expect(caption.itemTextLog()).toEqual(logStoreDummy.itemTextLog());
+      expect(caption.itemTextLog()).toEqual(voiceOverClientDummy.itemTextLog());
     });
   });
 

--- a/src/macOS/VoiceOver/VoiceOverCaption.ts
+++ b/src/macOS/VoiceOver/VoiceOverCaption.ts
@@ -1,16 +1,16 @@
 import type { CommandOptions } from "../../CommandOptions";
 import { copyLastSpokenPhrase } from "./copyLastSpokenPhrase";
-import { LogStore } from "./LogStore";
 import { saveLastSpokenPhrase } from "./saveLastSpokenPhrase";
+import { VoiceOverClient } from "./VoiceOverClient";
 
 export class VoiceOverCaption {
   /**
    * @ignore
    */
-  #logStore: LogStore;
+  #voiceOverClient: VoiceOverClient;
 
-  constructor(logStore: LogStore) {
-    this.#logStore = logStore;
+  constructor(voiceOverClient: VoiceOverClient) {
+    this.#voiceOverClient = voiceOverClient;
   }
 
   /**
@@ -19,7 +19,7 @@ export class VoiceOverCaption {
    * @returns {Promise<string>} The last spoken phrase.
    */
   async lastSpokenPhrase(): Promise<string> {
-    return await this.#logStore.lastSpokenPhrase();
+    return await this.#voiceOverClient.lastSpokenPhrase();
   }
 
   /**
@@ -52,7 +52,7 @@ export class VoiceOverCaption {
    * @returns {Promise<string>} The item's text.
    */
   async itemText(): Promise<string> {
-    return await this.#logStore.itemText();
+    return await this.#voiceOverClient.itemText();
   }
 
   /**
@@ -61,14 +61,14 @@ export class VoiceOverCaption {
    * @returns {Promise<string[]>} The spoken phrase log.
    */
   async spokenPhraseLog(): Promise<string[]> {
-    return await this.#logStore.spokenPhraseLog();
+    return await this.#voiceOverClient.spokenPhraseLog();
   }
 
   /**
    * Clear the log of all spoken phrases for this VoiceOver instance.
    */
   async clearSpokenPhraseLog(): Promise<void> {
-    await this.#logStore.clearSpokenPhraseLog();
+    await this.#voiceOverClient.clearSpokenPhraseLog();
   }
 
   /**
@@ -77,13 +77,13 @@ export class VoiceOverCaption {
    * @returns {Promise<string[]>} The item text log.
    */
   async itemTextLog(): Promise<string[]> {
-    return await this.#logStore.itemTextLog();
+    return await this.#voiceOverClient.itemTextLog();
   }
 
   /**
    * Clear the log of all visited item text for this VoiceOver instance.
    */
   async clearItemTextLog(): Promise<void> {
-    await this.#logStore.clearItemTextLog();
+    await this.#voiceOverClient.clearItemTextLog();
   }
 }

--- a/src/macOS/VoiceOver/VoiceOverClient.test.ts
+++ b/src/macOS/VoiceOver/VoiceOverClient.test.ts
@@ -1,8 +1,8 @@
 import { cleanSpokenPhrase } from "./cleanSpokenPhrase";
 import { itemText } from "./itemText";
 import { lastSpokenPhrase } from "./lastSpokenPhrase";
-import { LogStore } from "./LogStore";
 import { MAX_SPOKEN_PHRASES_POLL_COUNT } from "./constants";
+import { VoiceOverClient } from "./VoiceOverClient";
 
 jest.mock("./cleanSpokenPhrase", () => ({
   cleanSpokenPhrase: jest.fn(),
@@ -25,8 +25,8 @@ jest.mock("./lastSpokenPhrase", () => ({
 const itemTextDummy = "test-item-text";
 const lastSpokenPhraseDummy = "test-last-spoken-phrase";
 
-describe("LogStore", () => {
-  let logStore: LogStore;
+describe("VoiceOverClient", () => {
+  let voiceOverClient: VoiceOverClient;
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -41,26 +41,26 @@ describe("LogStore", () => {
 
   describe("when capture options are not provided", () => {
     beforeEach(() => {
-      logStore = new LogStore();
+      voiceOverClient = new VoiceOverClient();
     });
 
     it("should initialize with an empty item text log store", async () => {
-      expect(await logStore.itemTextLog()).toEqual([]);
+      expect(await voiceOverClient.itemTextLog()).toEqual([]);
     });
 
     it("should initialize with an empty spoken phrase log store", async () => {
-      expect(await logStore.spokenPhraseLog()).toEqual([]);
+      expect(await voiceOverClient.spokenPhraseLog()).toEqual([]);
     });
 
     it("should return with an empty string as the item text if not yet acted", async () => {
-      expect(await logStore.itemText()).toEqual("");
+      expect(await voiceOverClient.itemText()).toEqual("");
     });
 
     it("should return with an empty string as the last spoken phrase if not yet acted", async () => {
-      expect(await logStore.lastSpokenPhrase()).toEqual("");
+      expect(await voiceOverClient.lastSpokenPhrase()).toEqual("");
     });
 
-    describe("when tap is called on an action with no capture options", () => {
+    describe("when enqueueAndTap is called on an action with no capture options", () => {
       const expectedResult = Symbol("test-expected-result");
       let resultPromise: Promise<unknown>,
         resolver: (r: typeof expectedResult) => void;
@@ -71,7 +71,7 @@ describe("LogStore", () => {
             resolver = resolve;
           });
 
-        resultPromise = logStore.tap(action);
+        resultPromise = voiceOverClient.enqueueAndTap(action);
       });
 
       afterEach(async () => {
@@ -87,7 +87,7 @@ describe("LogStore", () => {
         it("should log the item text", async () => {
           await resultPromise;
 
-          expect(await logStore.itemTextLog()).toEqual([
+          expect(await voiceOverClient.itemTextLog()).toEqual([
             `cleaned_${itemTextDummy}`,
           ]);
         });
@@ -95,7 +95,7 @@ describe("LogStore", () => {
         it("should log the last spoken phrase", async () => {
           await resultPromise;
 
-          expect(await logStore.spokenPhraseLog()).toEqual([
+          expect(await voiceOverClient.spokenPhraseLog()).toEqual([
             `cleaned_${lastSpokenPhraseDummy}`,
           ]);
         });
@@ -105,18 +105,20 @@ describe("LogStore", () => {
         });
 
         it("should return the item text from the last action", async () => {
-          expect(await logStore.itemText()).toEqual(`cleaned_${itemTextDummy}`);
+          expect(await voiceOverClient.itemText()).toEqual(
+            `cleaned_${itemTextDummy}`,
+          );
         });
 
         it("should return the last spoken phrase from the last action", async () => {
-          expect(await logStore.lastSpokenPhrase()).toEqual(
-            `cleaned_${lastSpokenPhraseDummy}`
+          expect(await voiceOverClient.lastSpokenPhrase()).toEqual(
+            `cleaned_${lastSpokenPhraseDummy}`,
           );
         });
       });
     });
 
-    describe("when tap is called on an action with capture enabled", () => {
+    describe("when enqueueAndTap is called on an action with capture enabled", () => {
       const expectedResult = Symbol("test-expected-result");
       let resultPromise: Promise<unknown>,
         resolver: (r: typeof expectedResult) => void;
@@ -127,7 +129,9 @@ describe("LogStore", () => {
             resolver = resolve;
           });
 
-        resultPromise = logStore.tap(action, { capture: true });
+        resultPromise = voiceOverClient.enqueueAndTap(action, {
+          capture: true,
+        });
       });
 
       afterEach(async () => {
@@ -143,7 +147,7 @@ describe("LogStore", () => {
         it("should log the item text", async () => {
           await resultPromise;
 
-          expect(await logStore.itemTextLog()).toEqual([
+          expect(await voiceOverClient.itemTextLog()).toEqual([
             `cleaned_${itemTextDummy}`,
           ]);
         });
@@ -151,7 +155,7 @@ describe("LogStore", () => {
         it("should log the last spoken phrase", async () => {
           await resultPromise;
 
-          expect(await logStore.spokenPhraseLog()).toEqual([
+          expect(await voiceOverClient.spokenPhraseLog()).toEqual([
             `cleaned_${lastSpokenPhraseDummy}`,
           ]);
         });
@@ -161,18 +165,20 @@ describe("LogStore", () => {
         });
 
         it("should return the item text from the last action", async () => {
-          expect(await logStore.itemText()).toEqual(`cleaned_${itemTextDummy}`);
+          expect(await voiceOverClient.itemText()).toEqual(
+            `cleaned_${itemTextDummy}`,
+          );
         });
 
         it("should return the last spoken phrase from the last action", async () => {
-          expect(await logStore.lastSpokenPhrase()).toEqual(
-            `cleaned_${lastSpokenPhraseDummy}`
+          expect(await voiceOverClient.lastSpokenPhrase()).toEqual(
+            `cleaned_${lastSpokenPhraseDummy}`,
           );
         });
       });
     });
 
-    describe("when tap is called on an action with capture disabled", () => {
+    describe("when enqueueAndTap is called on an action with capture disabled", () => {
       const expectedResult = Symbol("test-expected-result");
       let resultPromise: Promise<unknown>,
         resolver: (r: typeof expectedResult) => void;
@@ -183,7 +189,9 @@ describe("LogStore", () => {
             resolver = resolve;
           });
 
-        resultPromise = logStore.tap(action, { capture: false });
+        resultPromise = voiceOverClient.enqueueAndTap(action, {
+          capture: false,
+        });
       });
 
       afterEach(async () => {
@@ -199,13 +207,13 @@ describe("LogStore", () => {
         it("should not log the item text", async () => {
           await resultPromise;
 
-          expect(await logStore.itemTextLog()).toHaveLength(0);
+          expect(await voiceOverClient.itemTextLog()).toHaveLength(0);
         });
 
         it("should not log the last spoken phrase", async () => {
           await resultPromise;
 
-          expect(await logStore.spokenPhraseLog()).toHaveLength(0);
+          expect(await voiceOverClient.spokenPhraseLog()).toHaveLength(0);
         });
 
         it("should return the action's result", async () => {
@@ -213,16 +221,16 @@ describe("LogStore", () => {
         });
 
         it("should not return the item text from the last action", async () => {
-          expect(await logStore.itemText()).toEqual("");
+          expect(await voiceOverClient.itemText()).toEqual("");
         });
 
         it("should not return the last spoken phrase from the last action", async () => {
-          expect(await logStore.lastSpokenPhrase()).toEqual("");
+          expect(await voiceOverClient.lastSpokenPhrase()).toEqual("");
         });
       });
     });
 
-    describe("when tap is called with capture enabled (by default or via options) but is unsuccessful in retrieving the last spoken phrase", () => {
+    describe("when enqueueAndTap is called with capture enabled (by default or via options) but is unsuccessful in retrieving the last spoken phrase", () => {
       const expectedResult = Symbol("test-expected-result");
       let resultPromise: Promise<unknown>,
         resolver: (r: typeof expectedResult) => void;
@@ -238,7 +246,7 @@ describe("LogStore", () => {
             resolver = resolve;
           });
 
-        resultPromise = logStore.tap(action);
+        resultPromise = voiceOverClient.enqueueAndTap(action);
       });
 
       afterEach(async () => {
@@ -255,25 +263,25 @@ describe("LogStore", () => {
           await resultPromise;
 
           expect(lastSpokenPhrase).toHaveBeenCalledTimes(
-            MAX_SPOKEN_PHRASES_POLL_COUNT
+            MAX_SPOKEN_PHRASES_POLL_COUNT,
           );
         });
 
         it("should not log any additional phrases", async () => {
-          expect(await logStore.spokenPhraseLog()).toEqual([""]);
+          expect(await voiceOverClient.spokenPhraseLog()).toEqual([""]);
 
           await resultPromise;
 
-          expect(await logStore.spokenPhraseLog()).toEqual([""]);
+          expect(await voiceOverClient.spokenPhraseLog()).toEqual([""]);
         });
 
         it("should return an empty string", async () => {
-          expect(await logStore.lastSpokenPhrase()).toEqual("");
+          expect(await voiceOverClient.lastSpokenPhrase()).toEqual("");
         });
       });
     });
 
-    describe("when tap is called with capture enabled (by default or via options) but the phrases emitted by VO never stabilize (e.g. live region that announces updates every second)", () => {
+    describe("when enqueueAndTap is called with capture enabled (by default or via options) but the phrases emitted by VO never stabilize (e.g. live region that announces updates every second)", () => {
       const expectedResult = Symbol("test-expected-result");
       let resultPromise: Promise<unknown>,
         resolver: (r: typeof expectedResult) => void;
@@ -289,7 +297,7 @@ describe("LogStore", () => {
             resolver = resolve;
           });
 
-        resultPromise = logStore.tap(action);
+        resultPromise = voiceOverClient.enqueueAndTap(action);
       });
 
       afterEach(async () => {
@@ -306,21 +314,21 @@ describe("LogStore", () => {
           await resultPromise;
 
           expect(lastSpokenPhrase).toHaveBeenCalledTimes(
-            MAX_SPOKEN_PHRASES_POLL_COUNT
+            MAX_SPOKEN_PHRASES_POLL_COUNT,
           );
         });
 
         it("should log the combined last spoken phrases", async () => {
           await resultPromise;
 
-          expect(await logStore.spokenPhraseLog()).toEqual([
+          expect(await voiceOverClient.spokenPhraseLog()).toEqual([
             `cleaned_0. cleaned_1. cleaned_2. cleaned_3`,
           ]);
         });
 
         it("should return the combined last spoken phrases from the last action", async () => {
-          expect(await logStore.lastSpokenPhrase()).toEqual(
-            `cleaned_0. cleaned_1. cleaned_2. cleaned_3`
+          expect(await voiceOverClient.lastSpokenPhrase()).toEqual(
+            `cleaned_0. cleaned_1. cleaned_2. cleaned_3`,
           );
         });
       });
@@ -329,30 +337,30 @@ describe("LogStore", () => {
 
   describe("when capture has been enabled by default", () => {
     beforeEach(() => {
-      logStore = new LogStore({ capture: true });
+      voiceOverClient = new VoiceOverClient({ capture: true });
     });
 
     it("should initialize with an empty item text log store", async () => {
-      expect(await logStore.itemTextLog()).toEqual([]);
+      expect(await voiceOverClient.itemTextLog()).toEqual([]);
     });
 
     it("should initialize with an empty spoken phrase log store", async () => {
-      expect(await logStore.spokenPhraseLog()).toEqual([]);
+      expect(await voiceOverClient.spokenPhraseLog()).toEqual([]);
     });
 
     it("should initialize with an empty spoken phrase log store", async () => {
-      expect(await logStore.spokenPhraseLog()).toEqual([]);
+      expect(await voiceOverClient.spokenPhraseLog()).toEqual([]);
     });
 
     it("should return with an empty string as the item text if not yet acted", async () => {
-      expect(await logStore.itemText()).toEqual("");
+      expect(await voiceOverClient.itemText()).toEqual("");
     });
 
     it("should return with an empty string as the last spoken phrase if not yet acted", async () => {
-      expect(await logStore.lastSpokenPhrase()).toEqual("");
+      expect(await voiceOverClient.lastSpokenPhrase()).toEqual("");
     });
 
-    describe("when tap is called on an action with no capture options", () => {
+    describe("when enqueueAndTap is called on an action with no capture options", () => {
       const expectedResult = Symbol("test-expected-result");
       let resultPromise: Promise<unknown>,
         resolver: (r: typeof expectedResult) => void;
@@ -363,7 +371,7 @@ describe("LogStore", () => {
             resolver = resolve;
           });
 
-        resultPromise = logStore.tap(action);
+        resultPromise = voiceOverClient.enqueueAndTap(action);
       });
 
       afterEach(async () => {
@@ -379,7 +387,7 @@ describe("LogStore", () => {
         it("should log the item text", async () => {
           await resultPromise;
 
-          expect(await logStore.itemTextLog()).toEqual([
+          expect(await voiceOverClient.itemTextLog()).toEqual([
             `cleaned_${itemTextDummy}`,
           ]);
         });
@@ -387,7 +395,7 @@ describe("LogStore", () => {
         it("should log the last spoken phrase", async () => {
           await resultPromise;
 
-          expect(await logStore.spokenPhraseLog()).toEqual([
+          expect(await voiceOverClient.spokenPhraseLog()).toEqual([
             `cleaned_${lastSpokenPhraseDummy}`,
           ]);
         });
@@ -397,18 +405,20 @@ describe("LogStore", () => {
         });
 
         it("should return the item text from the last action", async () => {
-          expect(await logStore.itemText()).toEqual(`cleaned_${itemTextDummy}`);
+          expect(await voiceOverClient.itemText()).toEqual(
+            `cleaned_${itemTextDummy}`,
+          );
         });
 
         it("should return the last spoken phrase from the last action", async () => {
-          expect(await logStore.lastSpokenPhrase()).toEqual(
-            `cleaned_${lastSpokenPhraseDummy}`
+          expect(await voiceOverClient.lastSpokenPhrase()).toEqual(
+            `cleaned_${lastSpokenPhraseDummy}`,
           );
         });
       });
     });
 
-    describe("when tap is called on an action with capture enabled", () => {
+    describe("when enqueueAndTap is called on an action with capture enabled", () => {
       const expectedResult = Symbol("test-expected-result");
       let resultPromise: Promise<unknown>,
         resolver: (r: typeof expectedResult) => void;
@@ -419,7 +429,9 @@ describe("LogStore", () => {
             resolver = resolve;
           });
 
-        resultPromise = logStore.tap(action, { capture: true });
+        resultPromise = voiceOverClient.enqueueAndTap(action, {
+          capture: true,
+        });
       });
 
       afterEach(async () => {
@@ -435,7 +447,7 @@ describe("LogStore", () => {
         it("should log the item text", async () => {
           await resultPromise;
 
-          expect(await logStore.itemTextLog()).toEqual([
+          expect(await voiceOverClient.itemTextLog()).toEqual([
             `cleaned_${itemTextDummy}`,
           ]);
         });
@@ -443,7 +455,7 @@ describe("LogStore", () => {
         it("should log the last spoken phrase", async () => {
           await resultPromise;
 
-          expect(await logStore.spokenPhraseLog()).toEqual([
+          expect(await voiceOverClient.spokenPhraseLog()).toEqual([
             `cleaned_${lastSpokenPhraseDummy}`,
           ]);
         });
@@ -453,46 +465,48 @@ describe("LogStore", () => {
         });
 
         it("should return the item text from the last action", async () => {
-          expect(await logStore.itemText()).toEqual(`cleaned_${itemTextDummy}`);
+          expect(await voiceOverClient.itemText()).toEqual(
+            `cleaned_${itemTextDummy}`,
+          );
         });
 
         it("should return the last spoken phrase from the last action", async () => {
-          expect(await logStore.lastSpokenPhrase()).toEqual(
-            `cleaned_${lastSpokenPhraseDummy}`
+          expect(await voiceOverClient.lastSpokenPhrase()).toEqual(
+            `cleaned_${lastSpokenPhraseDummy}`,
           );
         });
 
         describe("when the item text log is cleared", () => {
           beforeEach(async () => {
-            await logStore.clearItemTextLog();
+            await voiceOverClient.clearItemTextLog();
           });
 
           it("should return with an empty item text log store", async () => {
-            expect(await logStore.itemTextLog()).toEqual([]);
+            expect(await voiceOverClient.itemTextLog()).toEqual([]);
           });
 
           it("should return with an empty string as the item text", async () => {
-            expect(await logStore.itemText()).toEqual("");
+            expect(await voiceOverClient.itemText()).toEqual("");
           });
         });
 
         describe("when the spoken phrase log is cleared", () => {
           beforeEach(async () => {
-            await logStore.clearSpokenPhraseLog();
+            await voiceOverClient.clearSpokenPhraseLog();
           });
 
           it("should return with an empty spoken phrase log store", async () => {
-            expect(await logStore.spokenPhraseLog()).toEqual([]);
+            expect(await voiceOverClient.spokenPhraseLog()).toEqual([]);
           });
 
           it("should return with an empty string as the last spoken phrase", async () => {
-            expect(await logStore.lastSpokenPhrase()).toEqual("");
+            expect(await voiceOverClient.lastSpokenPhrase()).toEqual("");
           });
         });
       });
     });
 
-    describe("when tap is called on an action with capture disabled", () => {
+    describe("when enqueueAndTap is called on an action with capture disabled", () => {
       const expectedResult = Symbol("test-expected-result");
       let resultPromise: Promise<unknown>,
         resolver: (r: typeof expectedResult) => void;
@@ -503,7 +517,9 @@ describe("LogStore", () => {
             resolver = resolve;
           });
 
-        resultPromise = logStore.tap(action, { capture: false });
+        resultPromise = voiceOverClient.enqueueAndTap(action, {
+          capture: false,
+        });
       });
 
       afterEach(async () => {
@@ -519,13 +535,13 @@ describe("LogStore", () => {
         it("should not log the item text", async () => {
           await resultPromise;
 
-          expect(await logStore.itemTextLog()).toHaveLength(0);
+          expect(await voiceOverClient.itemTextLog()).toHaveLength(0);
         });
 
         it("should not log the last spoken phrase", async () => {
           await resultPromise;
 
-          expect(await logStore.spokenPhraseLog()).toHaveLength(0);
+          expect(await voiceOverClient.spokenPhraseLog()).toHaveLength(0);
         });
 
         it("should return the action's result", async () => {
@@ -533,11 +549,11 @@ describe("LogStore", () => {
         });
 
         it("should not return the item text from the last action", async () => {
-          expect(await logStore.itemText()).toEqual("");
+          expect(await voiceOverClient.itemText()).toEqual("");
         });
 
         it("should not return the last spoken phrase from the last action", async () => {
-          expect(await logStore.lastSpokenPhrase()).toEqual("");
+          expect(await voiceOverClient.lastSpokenPhrase()).toEqual("");
         });
       });
     });
@@ -545,30 +561,30 @@ describe("LogStore", () => {
 
   describe("when capture has been disabled by default", () => {
     beforeEach(() => {
-      logStore = new LogStore({ capture: false });
+      voiceOverClient = new VoiceOverClient({ capture: false });
     });
 
     it("should initialize with an empty item text log store", async () => {
-      expect(await logStore.itemTextLog()).toEqual([]);
+      expect(await voiceOverClient.itemTextLog()).toEqual([]);
     });
 
     it("should initialize with an empty spoken phrase log store", async () => {
-      expect(await logStore.spokenPhraseLog()).toEqual([]);
+      expect(await voiceOverClient.spokenPhraseLog()).toEqual([]);
     });
 
     it("should initialize with an empty spoken phrase log store", async () => {
-      expect(await logStore.spokenPhraseLog()).toEqual([]);
+      expect(await voiceOverClient.spokenPhraseLog()).toEqual([]);
     });
 
     it("should return with an empty string as the item text if not yet acted", async () => {
-      expect(await logStore.itemText()).toEqual("");
+      expect(await voiceOverClient.itemText()).toEqual("");
     });
 
     it("should return with an empty string as the last spoken phrase if not yet acted", async () => {
-      expect(await logStore.lastSpokenPhrase()).toEqual("");
+      expect(await voiceOverClient.lastSpokenPhrase()).toEqual("");
     });
 
-    describe("when tap is called on an action with no capture options", () => {
+    describe("when enqueueAndTap is called on an action with no capture options", () => {
       const expectedResult = Symbol("test-expected-result");
       let resultPromise: Promise<unknown>,
         resolver: (r: typeof expectedResult) => void;
@@ -579,7 +595,7 @@ describe("LogStore", () => {
             resolver = resolve;
           });
 
-        resultPromise = logStore.tap(action);
+        resultPromise = voiceOverClient.enqueueAndTap(action);
       });
 
       afterEach(async () => {
@@ -595,13 +611,13 @@ describe("LogStore", () => {
         it("should not log the item text", async () => {
           await resultPromise;
 
-          expect(await logStore.itemTextLog()).toHaveLength(0);
+          expect(await voiceOverClient.itemTextLog()).toHaveLength(0);
         });
 
         it("should not log the last spoken phrase", async () => {
           await resultPromise;
 
-          expect(await logStore.spokenPhraseLog()).toHaveLength(0);
+          expect(await voiceOverClient.spokenPhraseLog()).toHaveLength(0);
         });
 
         it("should return the action's result", async () => {
@@ -609,16 +625,16 @@ describe("LogStore", () => {
         });
 
         it("should not return the item text from the last action", async () => {
-          expect(await logStore.itemText()).toEqual("");
+          expect(await voiceOverClient.itemText()).toEqual("");
         });
 
         it("should not return the last spoken phrase from the last action", async () => {
-          expect(await logStore.lastSpokenPhrase()).toEqual("");
+          expect(await voiceOverClient.lastSpokenPhrase()).toEqual("");
         });
       });
     });
 
-    describe("when tap is called on an action with capture enabled", () => {
+    describe("when enqueueAndTap is called on an action with capture enabled", () => {
       const expectedResult = Symbol("test-expected-result");
       let resultPromise: Promise<unknown>,
         resolver: (r: typeof expectedResult) => void;
@@ -629,7 +645,9 @@ describe("LogStore", () => {
             resolver = resolve;
           });
 
-        resultPromise = logStore.tap(action, { capture: true });
+        resultPromise = voiceOverClient.enqueueAndTap(action, {
+          capture: true,
+        });
       });
 
       afterEach(async () => {
@@ -645,7 +663,7 @@ describe("LogStore", () => {
         it("should log the item text", async () => {
           await resultPromise;
 
-          expect(await logStore.itemTextLog()).toEqual([
+          expect(await voiceOverClient.itemTextLog()).toEqual([
             `cleaned_${itemTextDummy}`,
           ]);
         });
@@ -653,7 +671,7 @@ describe("LogStore", () => {
         it("should log the last spoken phrase", async () => {
           await resultPromise;
 
-          expect(await logStore.spokenPhraseLog()).toEqual([
+          expect(await voiceOverClient.spokenPhraseLog()).toEqual([
             `cleaned_${lastSpokenPhraseDummy}`,
           ]);
         });
@@ -663,18 +681,20 @@ describe("LogStore", () => {
         });
 
         it("should return the item text from the last action", async () => {
-          expect(await logStore.itemText()).toEqual(`cleaned_${itemTextDummy}`);
+          expect(await voiceOverClient.itemText()).toEqual(
+            `cleaned_${itemTextDummy}`,
+          );
         });
 
         it("should return the last spoken phrase from the last action", async () => {
-          expect(await logStore.lastSpokenPhrase()).toEqual(
-            `cleaned_${lastSpokenPhraseDummy}`
+          expect(await voiceOverClient.lastSpokenPhrase()).toEqual(
+            `cleaned_${lastSpokenPhraseDummy}`,
           );
         });
       });
     });
 
-    describe("when tap is called on an action with capture disabled", () => {
+    describe("when enqueueAndTap is called on an action with capture disabled", () => {
       const expectedResult = Symbol("test-expected-result");
       let resultPromise: Promise<unknown>,
         resolver: (r: typeof expectedResult) => void;
@@ -685,7 +705,9 @@ describe("LogStore", () => {
             resolver = resolve;
           });
 
-        resultPromise = logStore.tap(action, { capture: false });
+        resultPromise = voiceOverClient.enqueueAndTap(action, {
+          capture: false,
+        });
       });
 
       afterEach(async () => {
@@ -701,13 +723,13 @@ describe("LogStore", () => {
         it("should not log the item text", async () => {
           await resultPromise;
 
-          expect(await logStore.itemTextLog()).toHaveLength(0);
+          expect(await voiceOverClient.itemTextLog()).toHaveLength(0);
         });
 
         it("should not log the last spoken phrase", async () => {
           await resultPromise;
 
-          expect(await logStore.spokenPhraseLog()).toHaveLength(0);
+          expect(await voiceOverClient.spokenPhraseLog()).toHaveLength(0);
         });
 
         it("should return the action's result", async () => {
@@ -715,11 +737,11 @@ describe("LogStore", () => {
         });
 
         it("should not return the item text from the last action", async () => {
-          expect(await logStore.itemText()).toEqual("");
+          expect(await voiceOverClient.itemText()).toEqual("");
         });
 
         it("should not return the last spoken phrase from the last action", async () => {
-          expect(await logStore.lastSpokenPhrase()).toEqual("");
+          expect(await voiceOverClient.lastSpokenPhrase()).toEqual("");
         });
       });
     });

--- a/src/macOS/VoiceOver/VoiceOverClient.ts
+++ b/src/macOS/VoiceOver/VoiceOverClient.ts
@@ -8,6 +8,7 @@ import {
 } from "./constants";
 import { cleanSpokenPhrase } from "./cleanSpokenPhrase";
 import { CommandOptions } from "../../CommandOptions";
+import { ERR_VOICE_OVER_NOT_RUNNING } from "../errors";
 import { itemText as getItemText } from "./itemText";
 import { lastSpokenPhrase } from "./lastSpokenPhrase";
 
@@ -19,8 +20,18 @@ function countApproxWords(str) {
   return str.trim().split(/\s+/).length;
 }
 
-export class LogStore {
-  #activePromise = null;
+interface QueueAction {
+  action: () => Promise<unknown>;
+  options?: Pick<CommandOptions, "capture">;
+  promise: Promise<unknown>;
+  resolve: (value: unknown) => void;
+  reject: (reason?: unknown) => void;
+}
+
+export class VoiceOverClient {
+  #inFlight = false;
+  #queue: QueueAction[] = [];
+  #stopped = false;
   #capture: CommandOptions["capture"];
   #itemTextLogStore: string[] = [];
   #spokenPhraseLogStore: string[] = [];
@@ -28,6 +39,15 @@ export class LogStore {
 
   constructor(options?: Pick<CommandOptions, "capture">) {
     this.#capture = options?.capture ?? true;
+  }
+
+  /**
+   * Stop VoiceOver action execution.
+   */
+  async stop(): Promise<void> {
+    this.#stopped = true;
+
+    await Promise.allSettled(this.#queue.map(({ promise }) => promise));
   }
 
   /**
@@ -54,8 +74,8 @@ export class LogStore {
    * @returns {Promise<string[]>} The item text log.
    */
   async itemTextLog(): Promise<string[]> {
-    if (this.#activePromise) {
-      await this.#activePromise;
+    while (this.#inFlight) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
     }
 
     return this.#itemTextLogStore;
@@ -65,8 +85,8 @@ export class LogStore {
    * Clear the item text log.
    */
   async clearItemTextLog(): Promise<void> {
-    if (this.#activePromise) {
-      await this.#activePromise;
+    while (this.#inFlight) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
     }
 
     this.#itemTextLogStore = [];
@@ -78,8 +98,8 @@ export class LogStore {
    * @returns {Promise<string[]>} The spoken phrase log.
    */
   async spokenPhraseLog(): Promise<string[]> {
-    if (this.#activePromise) {
-      await this.#activePromise;
+    while (this.#inFlight) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
     }
 
     return this.#spokenPhraseLogStore;
@@ -89,8 +109,8 @@ export class LogStore {
    * Clear the spoken phrase log.
    */
   async clearSpokenPhraseLog(): Promise<void> {
-    if (this.#activePromise) {
-      await this.#activePromise;
+    while (this.#inFlight) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
     }
 
     // Keep a reference to the last spoken phrase so we can continue to use the
@@ -100,30 +120,49 @@ export class LogStore {
   }
 
   /**
-   * Waits for the provided promise to resolve and then captures the logs for
-   * the performed action until they stabilize.
+   * Enqueues an action and captures the logs for the performed action until
+   * they stabilize. Actions are executed serially in the order they are
+   * enqueued. Returns a promise that resolves with the action's result.
    *
-   * @param {Promise<unknown>} promise Underlying action to capture logs for.
+   * @param {() => Promise<T>} action The action to enqueue and execute.
    * @param {object} options Additional options.
-   * @returns {Promise<unknown>}
+   * @returns {Promise<T>} Promise that resolves with the action's result.
    */
-  async tap<T, S extends Promise<T>>(
+  async enqueueAndTap<T, S extends Promise<T>>(
     action: () => S,
-    options?: Pick<CommandOptions, "capture">
+    options?: Pick<CommandOptions, "capture">,
   ): Promise<T> {
-    if (this.#activePromise) {
-      await this.#activePromise;
+    if (this.#stopped) {
+      throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
-    let activePromiseResolver: () => void;
-    this.#activePromise = new Promise<void>(
-      (resolve) => (activePromiseResolver = resolve)
-    );
+    let resolve, reject;
 
-    let result: T;
+    const promise = new Promise<T>((_resolve, _reject) => {
+      resolve = _resolve;
+      reject = _reject;
+    });
+
+    this.#queue.push({ action, options, promise, resolve, reject });
+    this.#processQueue();
+
+    return promise;
+  }
+
+  async #processQueue() {
+    if (this.#inFlight || this.#queue.length === 0) {
+      return;
+    }
+
+    this.#inFlight = true;
+    const { action, options, resolve, reject } = this.#queue.shift()!;
 
     try {
-      result = await action();
+      if (this.#stopped) {
+        throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
+      }
+
+      const result = await action();
 
       if (options?.capture ?? this.#capture) {
         const [itemText, lastSpokenPhrase] = await Promise.all([
@@ -134,12 +173,14 @@ export class LogStore {
         this.#itemTextLogStore.push(itemText);
         this.#spokenPhraseLogStore.push(lastSpokenPhrase);
       }
-    } finally {
-      activePromiseResolver();
-      this.#activePromise = null;
-    }
 
-    return result;
+      resolve(result);
+    } catch (error) {
+      reject(error);
+    } finally {
+      this.#inFlight = false;
+      this.#processQueue();
+    }
   }
 
   async #pollForItemText() {

--- a/src/macOS/VoiceOver/VoiceOverCommander.test.ts
+++ b/src/macOS/VoiceOver/VoiceOverCommander.test.ts
@@ -1,16 +1,18 @@
 import { CommanderCommands } from "./CommanderCommands";
-import { LogStore } from "./LogStore";
 import { performCommand } from "./performCommand";
+import { VoiceOverClient } from "./VoiceOverClient";
 import { VoiceOverCommander } from "./VoiceOverCommander";
 
-jest.mock("./LogStore", () => ({
-  LogStore: jest.fn(),
+jest.mock("./VoiceOverClient", () => ({
+  VoiceOverClient: jest.fn(),
 }));
 jest.mock("./performCommand", () => ({
   performCommand: jest.fn(),
 }));
 
-const logStoreStub = { tap: jest.fn() } as unknown as LogStore;
+const voiceOverClientStub = {
+  enqueueAndTap: jest.fn(),
+} as unknown as VoiceOverClient;
 
 describe("VoiceOverCommander", () => {
   let commander: VoiceOverCommander;
@@ -20,10 +22,10 @@ describe("VoiceOverCommander", () => {
     jest.clearAllMocks();
 
     jest
-      .mocked(logStoreStub.tap)
+      .mocked(voiceOverClientStub.enqueueAndTap)
       .mockImplementation(async (action) => await action());
 
-    commander = new VoiceOverCommander(logStoreStub);
+    commander = new VoiceOverCommander(voiceOverClientStub);
   });
 
   describe("commands", () => {
@@ -46,14 +48,14 @@ describe("VoiceOverCommander", () => {
       it("should perform the provided command", () => {
         expect(performCommand).toHaveBeenCalledWith(
           CommanderCommands.ACTIONS,
-          options
+          options,
         );
       });
 
-      it("should tap the performCommand", () => {
-        expect(logStoreStub.tap).toHaveBeenCalledWith(
+      it("should enqueueAndTap the performCommand", () => {
+        expect(voiceOverClientStub.enqueueAndTap).toHaveBeenCalledWith(
           expect.any(Function),
-          options
+          options,
         );
       });
     });

--- a/src/macOS/VoiceOver/VoiceOverCommander.ts
+++ b/src/macOS/VoiceOver/VoiceOverCommander.ts
@@ -1,17 +1,17 @@
 import { CommanderCommands } from "./CommanderCommands";
 import { CommandOptions } from "../../CommandOptions";
-import { LogStore } from "./LogStore";
 import { performCommand } from "./performCommand";
 import { Prettify } from "../../typeHelpers";
+import { VoiceOverClient } from "./VoiceOverClient";
 
 export class VoiceOverCommander {
   /**
    * @ignore
    */
-  #logStore: LogStore;
+  #voiceOverClient: VoiceOverClient;
 
-  constructor(logStore: LogStore) {
-    this.#logStore = logStore;
+  constructor(voiceOverClient: VoiceOverClient) {
+    this.#voiceOverClient = voiceOverClient;
   }
 
   /**
@@ -29,11 +29,11 @@ export class VoiceOverCommander {
    */
   async perform(
     command: CommanderCommands,
-    options?: CommandOptions
+    options?: CommandOptions,
   ): Promise<void> {
-    return await this.#logStore.tap(
+    return await this.#voiceOverClient.enqueueAndTap(
       () => performCommand(command, options),
-      options
+      options,
     );
   }
 }

--- a/src/macOS/VoiceOver/VoiceOverCursor.test.ts
+++ b/src/macOS/VoiceOver/VoiceOverCursor.test.ts
@@ -1,15 +1,15 @@
 import { Applications } from "../Applications";
 import { Directions } from "./Directions";
 import { keyCodeCommands } from "./keyCodeCommands";
-import { LogStore } from "./LogStore";
 import { move } from "./move";
 import { performAction } from "./performAction";
 import { sendKeys } from "../sendKeys";
 import { takeScreenshot } from "./takeScreenshot";
+import { VoiceOverClient } from "./VoiceOverClient";
 import { VoiceOverCursor } from "./VoiceOverCursor";
 
-jest.mock("./LogStore", () => ({
-  LogStore: jest.fn(),
+jest.mock("./VoiceOverClient", () => ({
+  VoiceOverClient: jest.fn(),
 }));
 jest.mock("./move", () => ({
   move: jest.fn(),
@@ -24,7 +24,9 @@ jest.mock("./takeScreenshot", () => ({
   takeScreenshot: jest.fn(),
 }));
 
-const logStoreStub = { tap: jest.fn() } as unknown as LogStore;
+const voiceOverClientStub = {
+  enqueueAndTap: jest.fn(),
+} as unknown as VoiceOverClient;
 
 const screenshotPathDummy = "test-screenshot-path";
 
@@ -37,10 +39,10 @@ describe("VoiceOverCursor", () => {
 
     jest.mocked(takeScreenshot).mockResolvedValue(screenshotPathDummy);
     jest
-      .mocked(logStoreStub.tap)
+      .mocked(voiceOverClientStub.enqueueAndTap)
       .mockImplementation(async (action) => await action());
 
-    cursor = new VoiceOverCursor(logStoreStub);
+    cursor = new VoiceOverCursor(voiceOverClientStub);
   });
 
   describe("previous", () => {
@@ -58,10 +60,10 @@ describe("VoiceOverCursor", () => {
         expect(move).toHaveBeenCalledWith(Directions.Left, undefined, options);
       });
 
-      it("should tap the move", () => {
-        expect(logStoreStub.tap).toHaveBeenCalledWith(
+      it("should enqueueAndTap the move", () => {
+        expect(voiceOverClientStub.enqueueAndTap).toHaveBeenCalledWith(
           expect.any(Function),
-          options
+          options,
         );
       });
     });
@@ -81,10 +83,10 @@ describe("VoiceOverCursor", () => {
         expect(move).toHaveBeenCalledWith(Directions.Right, undefined, options);
       });
 
-      it("should tap the move", () => {
-        expect(logStoreStub.tap).toHaveBeenCalledWith(
+      it("should enqueueAndTap the move", () => {
+        expect(voiceOverClientStub.enqueueAndTap).toHaveBeenCalledWith(
           expect.any(Function),
-          options
+          options,
         );
       });
     });
@@ -104,10 +106,10 @@ describe("VoiceOverCursor", () => {
         expect(performAction).toHaveBeenCalledWith(options);
       });
 
-      it("should tap the action", () => {
-        expect(logStoreStub.tap).toHaveBeenCalledWith(
+      it("should enqueueAndTap the action", () => {
+        expect(voiceOverClientStub.enqueueAndTap).toHaveBeenCalledWith(
           expect.any(Function),
-          options
+          options,
         );
       });
     });
@@ -127,14 +129,14 @@ describe("VoiceOverCursor", () => {
         expect(sendKeys).toHaveBeenCalledWith(
           keyCodeCommands.interactWithItem,
           Applications.VoiceOver,
-          options
+          options,
         );
       });
 
-      it("should tap the sendKeys", () => {
-        expect(logStoreStub.tap).toHaveBeenCalledWith(
+      it("should enqueueAndTap the sendKeys", () => {
+        expect(voiceOverClientStub.enqueueAndTap).toHaveBeenCalledWith(
           expect.any(Function),
-          options
+          options,
         );
       });
     });
@@ -154,14 +156,14 @@ describe("VoiceOverCursor", () => {
         expect(sendKeys).toHaveBeenCalledWith(
           keyCodeCommands.stopInteractingWithItem,
           Applications.VoiceOver,
-          options
+          options,
         );
       });
 
-      it("should tap the sendKeys", () => {
-        expect(logStoreStub.tap).toHaveBeenCalledWith(
+      it("should enqueueAndTap the sendKeys", () => {
+        expect(voiceOverClientStub.enqueueAndTap).toHaveBeenCalledWith(
           expect.any(Function),
-          options
+          options,
         );
       });
     });

--- a/src/macOS/VoiceOver/VoiceOverCursor.ts
+++ b/src/macOS/VoiceOver/VoiceOverCursor.ts
@@ -2,20 +2,20 @@ import { Applications } from "../Applications";
 import type { CommandOptions } from "../../CommandOptions";
 import { Directions } from "./Directions";
 import { keyCodeCommands } from "./keyCodeCommands";
-import { LogStore } from "./LogStore";
 import { move } from "./move";
 import { performAction } from "./performAction";
 import { sendKeys } from "../sendKeys";
 import { takeScreenshot } from "./takeScreenshot";
+import { VoiceOverClient } from "./VoiceOverClient";
 
 export class VoiceOverCursor {
   /**
    * @ignore
    */
-  #logStore: LogStore;
+  #voiceOverClient: VoiceOverClient;
 
-  constructor(logStore: LogStore) {
-    this.#logStore = logStore;
+  constructor(voiceOverClient: VoiceOverClient) {
+    this.#voiceOverClient = voiceOverClient;
   }
 
   /**
@@ -26,9 +26,9 @@ export class VoiceOverCursor {
    * @param {object} [options] Additional options.
    */
   async previous(options?: CommandOptions): Promise<void> {
-    return await this.#logStore.tap(
+    return await this.#voiceOverClient.enqueueAndTap(
       () => move(Directions.Left, undefined, options),
-      options
+      options,
     );
   }
 
@@ -40,9 +40,9 @@ export class VoiceOverCursor {
    * @param {object} [options] Additional options.
    */
   async next(options?: CommandOptions): Promise<void> {
-    return await this.#logStore.tap(
+    return await this.#voiceOverClient.enqueueAndTap(
       () => move(Directions.Right, undefined, options),
-      options
+      options,
     );
   }
 
@@ -52,7 +52,10 @@ export class VoiceOverCursor {
    * @param {object} [options] Additional options.
    */
   async act(options?: CommandOptions): Promise<void> {
-    return await this.#logStore.tap(() => performAction(options), options);
+    return await this.#voiceOverClient.enqueueAndTap(
+      () => performAction(options),
+      options,
+    );
   }
 
   /**
@@ -63,14 +66,14 @@ export class VoiceOverCursor {
    * @param {object} [options] Additional options.
    */
   async interact(options?: CommandOptions): Promise<void> {
-    return await this.#logStore.tap(
+    return await this.#voiceOverClient.enqueueAndTap(
       () =>
         sendKeys(
           keyCodeCommands.interactWithItem,
           Applications.VoiceOver,
-          options
+          options,
         ),
-      options
+      options,
     );
   }
 
@@ -82,14 +85,14 @@ export class VoiceOverCursor {
    * @param {object} [options] Additional options.
    */
   async stopInteracting(options?: CommandOptions): Promise<void> {
-    return await this.#logStore.tap(
+    return await this.#voiceOverClient.enqueueAndTap(
       () =>
         sendKeys(
           keyCodeCommands.stopInteractingWithItem,
           Applications.VoiceOver,
-          options
+          options,
         ),
-      options
+      options,
     );
   }
 

--- a/src/macOS/VoiceOver/VoiceOverKeyboard.test.ts
+++ b/src/macOS/VoiceOver/VoiceOverKeyboard.test.ts
@@ -1,14 +1,14 @@
 import { Applications } from "../Applications";
 import { keyCodeCommands } from "./keyCodeCommands";
 import { KeyCodes } from "../KeyCodes";
-import { LogStore } from "./LogStore";
 import { Modifiers } from "../Modifiers";
 import { parseKey } from "../../parseKey";
 import { sendKeys } from "../sendKeys";
+import { VoiceOverClient } from "./VoiceOverClient";
 import { VoiceOverKeyboard } from "./VoiceOverKeyboard";
 
-jest.mock("./LogStore", () => ({
-  LogStore: jest.fn(),
+jest.mock("./VoiceOverClient", () => ({
+  VoiceOverClient: jest.fn(),
 }));
 jest.mock("../../parseKey", () => ({
   parseKey: jest.fn(),
@@ -17,7 +17,9 @@ jest.mock("../sendKeys", () => ({
   sendKeys: jest.fn(),
 }));
 
-const logStoreStub = { tap: jest.fn() } as unknown as LogStore;
+const voiceOverClientStub = {
+  enqueueAndTap: jest.fn(),
+} as unknown as VoiceOverClient;
 
 const applicationDummy = "test-application";
 const parsedKeyDummy = { keyCode: 123456 };
@@ -31,10 +33,10 @@ describe("VoiceOverKeyboard", () => {
 
     jest.mocked(parseKey).mockReturnValue(parsedKeyDummy);
     jest
-      .mocked(logStoreStub.tap)
+      .mocked(voiceOverClientStub.enqueueAndTap)
       .mockImplementation(async (action) => await action());
 
-    keyboard = new VoiceOverKeyboard(logStoreStub);
+    keyboard = new VoiceOverKeyboard(voiceOverClientStub);
   });
 
   describe("press", () => {
@@ -58,14 +60,14 @@ describe("VoiceOverKeyboard", () => {
         expect(sendKeys).toHaveBeenCalledWith(
           parsedKeyDummy,
           expectedApplication,
-          options
+          options,
         );
       });
 
-      it("should tap the sendKeys", () => {
-        expect(logStoreStub.tap).toHaveBeenCalledWith(
+      it("should enqueueAndTap the sendKeys", () => {
+        expect(voiceOverClientStub.enqueueAndTap).toHaveBeenCalledWith(
           expect.any(Function),
-          options
+          options,
         );
       });
     });
@@ -88,14 +90,14 @@ describe("VoiceOverKeyboard", () => {
         expect(sendKeys).toHaveBeenCalledWith(
           { characters: textDummy },
           expectedApplication,
-          options
+          options,
         );
       });
 
-      it("should tap the sendKeys", () => {
-        expect(logStoreStub.tap).toHaveBeenCalledWith(
+      it("should enqueueAndTap the sendKeys", () => {
+        expect(voiceOverClientStub.enqueueAndTap).toHaveBeenCalledWith(
           expect.any(Function),
-          options
+          options,
         );
       });
     });
@@ -121,14 +123,14 @@ describe("VoiceOverKeyboard", () => {
         expect(sendKeys).toHaveBeenCalledWith(
           keyCodeCommands.interactWithItem,
           Applications.VoiceOver,
-          options
+          options,
         );
       });
 
-      it("should tap the sendKeys", () => {
-        expect(logStoreStub.tap).toHaveBeenCalledWith(
+      it("should enqueueAndTap the sendKeys", () => {
+        expect(voiceOverClientStub.enqueueAndTap).toHaveBeenCalledWith(
           expect.any(Function),
-          options
+          options,
         );
       });
     });

--- a/src/macOS/VoiceOver/VoiceOverKeyboard.ts
+++ b/src/macOS/VoiceOver/VoiceOverKeyboard.ts
@@ -5,20 +5,20 @@ import type { KeyboardOptions } from "../../KeyboardOptions";
 import type { KeyCodeCommand } from "../KeyCodeCommand";
 import { keyCodeCommands } from "./keyCodeCommands";
 import { KeyCodes } from "../KeyCodes";
-import { LogStore } from "./LogStore";
 import { Modifiers } from "../Modifiers";
 import { parseKey } from "../../parseKey";
 import type { Prettify } from "../../typeHelpers";
 import { sendKeys } from "../sendKeys";
+import { VoiceOverClient } from "./VoiceOverClient";
 
 export class VoiceOverKeyboard {
   /**
    * @ignore
    */
-  #logStore: LogStore;
+  #voiceOverClient: VoiceOverClient;
 
-  constructor(vo: LogStore) {
-    this.#logStore = vo;
+  constructor(vo: VoiceOverClient) {
+    this.#voiceOverClient = vo;
   }
 
   /**
@@ -49,14 +49,14 @@ export class VoiceOverKeyboard {
    * @param {object} [options] Additional options.
    */
   async press(key: string, options?: KeyboardOptions): Promise<void> {
-    return await this.#logStore.tap(
+    return await this.#voiceOverClient.enqueueAndTap(
       () =>
         sendKeys(
           parseKey<KeyCodeCommand>(key, Modifiers, KeyCodes),
           options?.application,
-          options
+          options,
         ),
-      options
+      options,
     );
   }
 
@@ -74,9 +74,9 @@ export class VoiceOverKeyboard {
    * @param {object} [options] Additional options.
    */
   async type(text: string, options?: KeyboardOptions): Promise<void> {
-    return await this.#logStore.tap(
+    return await this.#voiceOverClient.enqueueAndTap(
       () => sendKeys({ characters: text }, options?.application, options),
-      options
+      options,
     );
   }
 
@@ -97,11 +97,11 @@ export class VoiceOverKeyboard {
    */
   async perform(
     command: KeyboardCommand,
-    options?: CommandOptions
+    options?: CommandOptions,
   ): Promise<void> {
-    return await this.#logStore.tap(
+    return await this.#voiceOverClient.enqueueAndTap(
       () => sendKeys(command, Applications.VoiceOver, options),
-      options
+      options,
     );
   }
 }

--- a/src/macOS/VoiceOver/VoiceOverMouse.test.ts
+++ b/src/macOS/VoiceOver/VoiceOverMouse.test.ts
@@ -1,15 +1,17 @@
 import { click } from "./click";
-import { LogStore } from "./LogStore";
+import { VoiceOverClient } from "./VoiceOverClient";
 import { VoiceOverMouse } from "./VoiceOverMouse";
 
 jest.mock("./click", () => ({
   click: jest.fn(),
 }));
-jest.mock("./LogStore", () => ({
-  LogStore: jest.fn(),
+jest.mock("./VoiceOverClient", () => ({
+  VoiceOverClient: jest.fn(),
 }));
 
-const logStoreStub = { tap: jest.fn() } as unknown as LogStore;
+const voiceOverClientStub = {
+  enqueueAndTap: jest.fn(),
+} as unknown as VoiceOverClient;
 
 describe("VoiceOverMouse", () => {
   let mouse: VoiceOverMouse;
@@ -19,10 +21,10 @@ describe("VoiceOverMouse", () => {
     jest.clearAllMocks();
 
     jest
-      .mocked(logStoreStub.tap)
+      .mocked(voiceOverClientStub.enqueueAndTap)
       .mockImplementation(async (action) => await action());
 
-    mouse = new VoiceOverMouse(logStoreStub);
+    mouse = new VoiceOverMouse(voiceOverClientStub);
   });
 
   describe("click", () => {
@@ -39,10 +41,10 @@ describe("VoiceOverMouse", () => {
         expect(click).toHaveBeenCalledWith(options);
       });
 
-      it("should tap the click", () => {
-        expect(logStoreStub.tap).toHaveBeenCalledWith(
+      it("should enqueueAndTap the click", () => {
+        expect(voiceOverClientStub.enqueueAndTap).toHaveBeenCalledWith(
           expect.any(Function),
-          options
+          options,
         );
       });
     });

--- a/src/macOS/VoiceOver/VoiceOverMouse.ts
+++ b/src/macOS/VoiceOver/VoiceOverMouse.ts
@@ -1,15 +1,15 @@
 import { click } from "./click";
 import type { ClickOptions } from "../../ClickOptions";
-import { LogStore } from "./LogStore";
+import { VoiceOverClient } from "./VoiceOverClient";
 
 export class VoiceOverMouse {
   /**
    * @ignore
    */
-  #logStore: LogStore;
+  #voiceOverClient: VoiceOverClient;
 
-  constructor(logStore: LogStore) {
-    this.#logStore = logStore;
+  constructor(voiceOverClient: VoiceOverClient) {
+    this.#voiceOverClient = voiceOverClient;
   }
 
   /**
@@ -18,6 +18,9 @@ export class VoiceOverMouse {
    * @param {object} [options] Click options.
    */
   async click(options?: ClickOptions): Promise<void> {
-    return await this.#logStore.tap(() => click(options), options);
+    return await this.#voiceOverClient.enqueueAndTap(
+      () => click(options),
+      options,
+    );
   }
 }

--- a/src/macOS/VoiceOver/isRunning.test.ts
+++ b/src/macOS/VoiceOver/isRunning.test.ts
@@ -24,13 +24,13 @@ describe("isRunning", () => {
     ${"without options"} | ${undefined}
     ${"with options"}    | ${{}}
   `("when called $description", ({ options }) => {
-    let result;
+    let result: unknown;
 
     const commonProcessAssertions = () => {
       it("should check to see if the process is running", () => {
         expect(exec).toHaveBeenCalledWith(
           'ps aux | egrep "[V]oiceOver"',
-          expect.any(Function)
+          expect.any(Function),
         );
       });
     };
@@ -38,7 +38,7 @@ describe("isRunning", () => {
     const commonAppleScriptRunningAssertions = () => {
       it("should check to see if the application is running via AppleScript", () => {
         expect(runAppleScript).toHaveBeenCalledWith(
-          `tell application "${Applications.VoiceOver}"\nreturn running\nend tell`
+          `tell application "${Applications.VoiceOver}"\nreturn running\nend tell`,
         );
       });
     };
@@ -114,7 +114,7 @@ describe("isRunning", () => {
         });
       });
 
-      describe("when called without a skipActivate argument", () => {
+      describe("when called without a skipAppleScript argument", () => {
         describe("when AppleScript says VoiceOver is running", () => {
           beforeEach(() => {
             jest.mocked(runAppleScript).mockResolvedValue("true");
@@ -156,7 +156,7 @@ describe("isRunning", () => {
         });
       });
 
-      describe("when called with skipActivate set to false", () => {
+      describe("when called with skipAppleScript set to false", () => {
         describe("when AppleScript says VoiceOver is running", () => {
           beforeEach(() => {
             jest.mocked(runAppleScript).mockResolvedValue("true");
@@ -198,7 +198,7 @@ describe("isRunning", () => {
         });
       });
 
-      describe("when called with skipActivate set to true", () => {
+      describe("when called with skipAppleScript set to true", () => {
         describe("when AppleScript says VoiceOver is running", () => {
           beforeEach(async () => {
             jest.mocked(runAppleScript).mockResolvedValue("true");
@@ -207,7 +207,6 @@ describe("isRunning", () => {
           });
 
           commonProcessAssertions();
-          commonAppleScriptRunningAssertions();
 
           it("should not try to activate VoiceOver", () => {
             expect(activate).not.toHaveBeenCalled();

--- a/src/macOS/VoiceOver/isRunning.ts
+++ b/src/macOS/VoiceOver/isRunning.ts
@@ -6,7 +6,7 @@ import { runAppleScript } from "../runAppleScript";
 
 export async function isRunning(
   options?: CommandOptions,
-  skipActivate = false
+  skipAppleScript = false,
 ): Promise<boolean> {
   const processRunning = await new Promise<boolean>((resolve) => {
     exec('ps aux | egrep "[V]oiceOver"', (err, stdout) => {
@@ -22,16 +22,16 @@ export async function isRunning(
     return false;
   }
 
+  if (skipAppleScript) {
+    return true;
+  }
+
   const appleScriptRunning = await runAppleScript<string>(
-    `tell application "${Applications.VoiceOver}"\nreturn running\nend tell`
+    `tell application "${Applications.VoiceOver}"\nreturn running\nend tell`,
   );
 
   if (appleScriptRunning === "false") {
     return false;
-  }
-
-  if (skipActivate) {
-    return true;
   }
 
   try {

--- a/src/macOS/VoiceOver/terminateVoiceOverProcess.test.ts
+++ b/src/macOS/VoiceOver/terminateVoiceOverProcess.test.ts
@@ -1,9 +1,23 @@
 import { ChildProcess, exec } from "child_process";
+import { keyCodeCommands } from "./keyCodeCommands";
+import { MacOSApplications } from "..";
+import { quit } from "../quit";
+import { sendKeys } from "../sendKeys";
 import { terminateVoiceOverProcess } from "./terminateVoiceOverProcess";
 
 jest.mock("child_process", () => ({
   exec: jest.fn(),
 }));
+
+jest.mock("../quit", () => ({
+  quit: jest.fn(),
+}));
+
+jest.mock("../sendKeys", () => ({
+  sendKeys: jest.fn(),
+}));
+
+const optionsDummy = {};
 
 describe("terminateVoiceOverProcess", () => {
   beforeEach(async () => {
@@ -14,13 +28,28 @@ describe("terminateVoiceOverProcess", () => {
       return {} as unknown as ChildProcess;
     });
 
-    await terminateVoiceOverProcess();
+    await terminateVoiceOverProcess(optionsDummy);
+  });
+
+  it("should attempt to a quit key code command to the VoiceOver application", () => {
+    expect(sendKeys).toHaveBeenCalledWith(
+      keyCodeCommands.quit,
+      MacOSApplications.VoiceOver,
+      optionsDummy,
+    );
+  });
+
+  it("should attempt an AppleScript based quit of the VoiceOver application", () => {
+    expect(quit).toHaveBeenCalledWith(
+      MacOSApplications.VoiceOver,
+      optionsDummy,
+    );
   });
 
   it("should attempt to terminate (kill -15) the VoiceOver process (SIGTERM over SIGKILL owing to the process being run by launchd)", () => {
     expect(exec).toHaveBeenCalledWith(
       `kill -15 $(ps aux | egrep "[V]oiceOver.app/Contents/MacOS/VoiceOver launchd -s" | awk '{print $2}')`,
-      expect.any(Function)
+      expect.any(Function),
     );
   });
 });

--- a/src/macOS/VoiceOver/terminateVoiceOverProcess.ts
+++ b/src/macOS/VoiceOver/terminateVoiceOverProcess.ts
@@ -1,12 +1,27 @@
 import { exec } from "child_process";
+import { MacOSApplications } from "..";
+import { quit } from "../quit";
+import { sendKeys } from "../sendKeys";
+import { CommandOptions } from "../../CommandOptions";
+import { keyCodeCommands } from "./keyCodeCommands";
 
-export async function terminateVoiceOverProcess(): Promise<void> {
-  return new Promise<void>((resolve) => {
+export async function terminateVoiceOverProcess(
+  options?: CommandOptions,
+): Promise<void> {
+  // Most reliable way (weirdly) is generally via the keyboard command to quit
+  // VoiceOver.
+  await sendKeys(keyCodeCommands.quit, MacOSApplications.VoiceOver, options);
+
+  // Failing that we attempt to stop VoiceOver via it's AppleScript API.
+  await quit(MacOSApplications.VoiceOver, options);
+
+  // Final fallback to trying to kill the launchd process.
+  await new Promise<void>((resolve) => {
     exec(
       `kill -15 $(ps aux | egrep "[V]oiceOver.app/Contents/MacOS/VoiceOver launchd -s" | awk '{print $2}')`,
       () => {
         resolve();
-      }
+      },
     );
   });
 }

--- a/src/macOS/VoiceOver/terminateVoiceOverProcess.ts
+++ b/src/macOS/VoiceOver/terminateVoiceOverProcess.ts
@@ -1,15 +1,15 @@
+import { CommandOptions } from "../../CommandOptions";
 import { exec } from "child_process";
+import { keyCodeCommands } from "./keyCodeCommands";
 import { MacOSApplications } from "..";
 import { quit } from "../quit";
 import { sendKeys } from "../sendKeys";
-import { CommandOptions } from "../../CommandOptions";
-import { keyCodeCommands } from "./keyCodeCommands";
 
 export async function terminateVoiceOverProcess(
   options?: CommandOptions,
 ): Promise<void> {
-  // Most reliable way (weirdly) is generally via the keyboard command to quit
-  // VoiceOver.
+  // Most reliable way (counter-intuitively) is via the keyboard command to
+  // quit VoiceOver.
   await sendKeys(keyCodeCommands.quit, MacOSApplications.VoiceOver, options);
 
   // Failing that we attempt to stop VoiceOver via it's AppleScript API.

--- a/src/macOS/errors.ts
+++ b/src/macOS/errors.ts
@@ -4,8 +4,6 @@ export const ERR_VOICE_OVER_NOT_RUNNING = "VoiceOver not running";
 export const ERR_VOICE_OVER_UNABLE_TO_CONFIGURE_VOICEOVER_SETTING =
   "Unable to configure a VoiceOver setting";
 export const ERR_VOICE_OVER_CANNOT_BE_STARTED = "VoiceOver cannot be started";
-export const ERR_VOICE_OVER_CANNOT_BE_STARTED_AS_STOPPING =
-  "VoiceOver cannot be started as it is currently stopping";
 
 export const ERR_VOICE_OVER_RUNNING_TIMEOUT =
   "Timed out waiting for VoiceOver to be running";

--- a/src/macOS/errors.ts
+++ b/src/macOS/errors.ts
@@ -4,6 +4,8 @@ export const ERR_VOICE_OVER_NOT_RUNNING = "VoiceOver not running";
 export const ERR_VOICE_OVER_UNABLE_TO_CONFIGURE_VOICEOVER_SETTING =
   "Unable to configure a VoiceOver setting";
 export const ERR_VOICE_OVER_CANNOT_BE_STARTED = "VoiceOver cannot be started";
+export const ERR_VOICE_OVER_CANNOT_BE_STARTED_AS_STOPPING =
+  "VoiceOver cannot be started as it is currently stopping";
 
 export const ERR_VOICE_OVER_RUNNING_TIMEOUT =
   "Timed out waiting for VoiceOver to be running";

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,12 +24,13 @@
     chalk "^2.4.2"
 
 "@babel/code-frame@^7.12.13":
-  version "7.23.5"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.23.5.tgz#9009b69a8c602293476ad598ff53e4562e15c244"
-  integrity sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
+  integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
   dependencies:
-    "@babel/highlight" "^7.23.4"
-    chalk "^2.4.2"
+    "@babel/helper-validator-identifier" "^7.29.7"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
 
 "@babel/compat-data@^7.22.9":
   version "7.22.20"
@@ -140,10 +141,10 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
   integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
 
-"@babel/helper-validator-identifier@^7.22.20":
-  version "7.22.20"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz#c4ae002c61d2879e724581d96665583dbc1dc0e0"
-  integrity sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==
+"@babel/helper-validator-identifier@^7.22.20", "@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
 
 "@babel/helper-validator-option@^7.22.15":
   version "7.22.15"
@@ -159,7 +160,7 @@
     "@babel/traverse" "^7.23.0"
     "@babel/types" "^7.23.0"
 
-"@babel/highlight@^7.22.13", "@babel/highlight@^7.23.4":
+"@babel/highlight@^7.22.13":
   version "7.23.4"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.23.4.tgz#edaadf4d8232e1a961432db785091207ead0621b"
   integrity sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==
@@ -317,14 +318,26 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
+"@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
   integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
   dependencies:
     eslint-visitor-keys "^3.3.0"
 
-"@eslint-community/regexpp@^4.10.0", "@eslint-community/regexpp@^4.6.1":
+"@eslint-community/eslint-utils@^4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz#4e90af67bc51ddee6cdef5284edf572ec376b595"
+  integrity sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==
+  dependencies:
+    eslint-visitor-keys "^3.4.3"
+
+"@eslint-community/regexpp@^4.12.2":
+  version "4.12.2"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.2.tgz#bccdf615bcf7b6e8db830ec0b8d21c9a25de597b"
+  integrity sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==
+
+"@eslint-community/regexpp@^4.6.1":
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.11.0.tgz#b0ffd0312b4a3fd2d6f77237e7248a5ad3a680ae"
   integrity sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==
@@ -367,18 +380,6 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
-
-"@isaacs/cliui@^8.0.2":
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
-  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
-  dependencies:
-    string-width "^5.1.2"
-    string-width-cjs "npm:string-width@^4.2.0"
-    strip-ansi "^7.0.1"
-    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
-    wrap-ansi "^8.1.0"
-    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -641,12 +642,12 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+"@nodelib/fs.stat@2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
 
-"@nodelib/fs.walk@^1.2.3", "@nodelib/fs.walk@^1.2.8":
+"@nodelib/fs.walk@^1.2.8":
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
   integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
@@ -655,9 +656,9 @@
     fastq "^1.6.0"
 
 "@sinclair/typebox@^0.27.8":
-  version "0.27.8"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
-  integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
+  version "0.27.10"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.10.tgz#beefe675f1853f73676aecc915b2bd2ac98c4fc6"
+  integrity sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==
 
 "@sinonjs/commons@^3.0.0":
   version "3.0.0"
@@ -758,26 +759,26 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/jest@^29.5.13":
-  version "29.5.13"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.13.tgz#8bc571659f401e6a719a7bf0dbcb8b78c71a8adc"
-  integrity sha512-wd+MVEZCHt23V0/L642O5APvspWply/rGY5BcW4SUETo2UzPU3Z26qr8jC2qxpimI2jjx9h7+2cj2FwIr01bXg==
+  version "29.5.14"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.14.tgz#2b910912fa1d6856cadcd0c1f95af7df1d6049e5"
+  integrity sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
 "@types/node@*":
-  version "20.11.24"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.24.tgz#cc207511104694e84e9fb17f9a0c4c42d4517792"
-  integrity sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==
+  version "25.9.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.3.tgz#11dfe7a33e68fa5c560f0aa76cc5595621ef26b9"
+  integrity sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==
   dependencies:
-    undici-types "~5.26.4"
+    undici-types ">=7.24.0 <7.24.7"
 
 "@types/node@^22.5.5":
-  version "22.5.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.5.tgz#52f939dd0f65fc552a4ad0b392f3c466cc5d7a44"
-  integrity sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==
+  version "22.19.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.19.21.tgz#5c9d843ea385b31ee937a9f743443830620a32de"
+  integrity sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==
   dependencies:
-    undici-types "~6.19.2"
+    undici-types "~6.21.0"
 
 "@types/stack-utils@^2.0.0":
   version "2.0.3"
@@ -790,92 +791,107 @@
   integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
 
 "@types/yargs@^17.0.8":
-  version "17.0.32"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.32.tgz#030774723a2f7faafebf645f4e5a48371dca6229"
-  integrity sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==
+  version "17.0.35"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.35.tgz#07013e46aa4d7d7d50a49e15604c1c5340d4eb24"
+  integrity sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==
   dependencies:
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^8.5.0":
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.5.0.tgz#7c1863693a98371703686e1c0fac64ffc576cdb1"
-  integrity sha512-lHS5hvz33iUFQKuPFGheAB84LwcJ60G8vKnEhnfcK1l8kGVLro2SFYW6K0/tj8FUhRJ0VHyg1oAfg50QGbPPHw==
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz#db20271974b94a3a54d3b9544e5f5b3481448400"
+  integrity sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==
   dependencies:
-    "@eslint-community/regexpp" "^4.10.0"
-    "@typescript-eslint/scope-manager" "8.5.0"
-    "@typescript-eslint/type-utils" "8.5.0"
-    "@typescript-eslint/utils" "8.5.0"
-    "@typescript-eslint/visitor-keys" "8.5.0"
-    graphemer "^1.4.0"
-    ignore "^5.3.1"
+    "@eslint-community/regexpp" "^4.12.2"
+    "@typescript-eslint/scope-manager" "8.61.0"
+    "@typescript-eslint/type-utils" "8.61.0"
+    "@typescript-eslint/utils" "8.61.0"
+    "@typescript-eslint/visitor-keys" "8.61.0"
+    ignore "^7.0.5"
     natural-compare "^1.4.0"
-    ts-api-utils "^1.3.0"
+    ts-api-utils "^2.5.0"
 
 "@typescript-eslint/parser@^8.5.0":
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.5.0.tgz#d590e1ef9f31f26d423999ad3f687723247e6bcc"
-  integrity sha512-gF77eNv0Xz2UJg/NbpWJ0kqAm35UMsvZf1GHj8D9MRFTj/V3tAciIWXfmPLsAAF/vUlpWPvUDyH1jjsr0cMVWw==
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.61.0.tgz#1afe73c9ccce16b7a26d6b95f9400b0ccc34af87"
+  integrity sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==
   dependencies:
-    "@typescript-eslint/scope-manager" "8.5.0"
-    "@typescript-eslint/types" "8.5.0"
-    "@typescript-eslint/typescript-estree" "8.5.0"
-    "@typescript-eslint/visitor-keys" "8.5.0"
-    debug "^4.3.4"
+    "@typescript-eslint/scope-manager" "8.61.0"
+    "@typescript-eslint/types" "8.61.0"
+    "@typescript-eslint/typescript-estree" "8.61.0"
+    "@typescript-eslint/visitor-keys" "8.61.0"
+    debug "^4.4.3"
 
-"@typescript-eslint/scope-manager@8.5.0":
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.5.0.tgz#385341de65b976f02b295b8aca54bb4ffd6b5f07"
-  integrity sha512-06JOQ9Qgj33yvBEx6tpC8ecP9o860rsR22hWMEd12WcTRrfaFgHr2RB/CA/B+7BMhHkXT4chg2MyboGdFGawYg==
+"@typescript-eslint/project-service@8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.61.0.tgz#417a2feac32e8ebd336d63f068c3b42b736ea1ac"
+  integrity sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==
   dependencies:
-    "@typescript-eslint/types" "8.5.0"
-    "@typescript-eslint/visitor-keys" "8.5.0"
+    "@typescript-eslint/tsconfig-utils" "^8.61.0"
+    "@typescript-eslint/types" "^8.61.0"
+    debug "^4.4.3"
 
-"@typescript-eslint/type-utils@8.5.0":
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.5.0.tgz#6215b23aa39dbbd8dde0a4ef9ee0f745410c29b1"
-  integrity sha512-N1K8Ix+lUM+cIDhL2uekVn/ZD7TZW+9/rwz8DclQpcQ9rk4sIL5CAlBC0CugWKREmDjBzI/kQqU4wkg46jWLYA==
+"@typescript-eslint/scope-manager@8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz#93c2520d05653fe65eb9ee98efc74fd0134a7852"
+  integrity sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==
   dependencies:
-    "@typescript-eslint/typescript-estree" "8.5.0"
-    "@typescript-eslint/utils" "8.5.0"
-    debug "^4.3.4"
-    ts-api-utils "^1.3.0"
+    "@typescript-eslint/types" "8.61.0"
+    "@typescript-eslint/visitor-keys" "8.61.0"
 
-"@typescript-eslint/types@8.5.0":
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.5.0.tgz#4465d99331d1276f8fb2030e4f9c73fe01a05bf9"
-  integrity sha512-qjkormnQS5wF9pjSi6q60bKUHH44j2APxfh9TQRXK8wbYVeDYYdYJGIROL87LGZZ2gz3Rbmjc736qyL8deVtdw==
+"@typescript-eslint/tsconfig-utils@8.61.0", "@typescript-eslint/tsconfig-utils@^8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz#05d6e3ff20001674ebcd22d03dac29ee448043ba"
+  integrity sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==
 
-"@typescript-eslint/typescript-estree@8.5.0":
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.5.0.tgz#6e5758cf2f63aa86e9ddfa4e284e2e0b81b87557"
-  integrity sha512-vEG2Sf9P8BPQ+d0pxdfndw3xIXaoSjliG0/Ejk7UggByZPKXmJmw3GW5jV2gHNQNawBUyfahoSiCFVov0Ruf7Q==
+"@typescript-eslint/type-utils@8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz#50219b57e6b89cecfb1a15f093b15ec9ee019974"
+  integrity sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==
   dependencies:
-    "@typescript-eslint/types" "8.5.0"
-    "@typescript-eslint/visitor-keys" "8.5.0"
-    debug "^4.3.4"
-    fast-glob "^3.3.2"
-    is-glob "^4.0.3"
-    minimatch "^9.0.4"
-    semver "^7.6.0"
-    ts-api-utils "^1.3.0"
+    "@typescript-eslint/types" "8.61.0"
+    "@typescript-eslint/typescript-estree" "8.61.0"
+    "@typescript-eslint/utils" "8.61.0"
+    debug "^4.4.3"
+    ts-api-utils "^2.5.0"
 
-"@typescript-eslint/utils@8.5.0":
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.5.0.tgz#4d4ffed96d0654546a37faa5b84bdce16d951634"
-  integrity sha512-6yyGYVL0e+VzGYp60wvkBHiqDWOpT63pdMV2CVG4LVDd5uR6q1qQN/7LafBZtAtNIn/mqXjsSeS5ggv/P0iECw==
-  dependencies:
-    "@eslint-community/eslint-utils" "^4.4.0"
-    "@typescript-eslint/scope-manager" "8.5.0"
-    "@typescript-eslint/types" "8.5.0"
-    "@typescript-eslint/typescript-estree" "8.5.0"
+"@typescript-eslint/types@8.61.0", "@typescript-eslint/types@^8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.61.0.tgz#0ddb46e012a4288292950bdd253db42f278ce64d"
+  integrity sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==
 
-"@typescript-eslint/visitor-keys@8.5.0":
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.5.0.tgz#13028df3b866d2e3e2e2cc4193cf2c1e0e04c4bf"
-  integrity sha512-yTPqMnbAZJNy2Xq2XU8AdtOW9tJIr+UQb64aXB9f3B1498Zx9JorVgFJcZpEc9UBuCCrdzKID2RGAMkYcDtZOw==
+"@typescript-eslint/typescript-estree@8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz#98ca47260bbf627fc28f018b3a0abf00e3090690"
+  integrity sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==
   dependencies:
-    "@typescript-eslint/types" "8.5.0"
-    eslint-visitor-keys "^3.4.3"
+    "@typescript-eslint/project-service" "8.61.0"
+    "@typescript-eslint/tsconfig-utils" "8.61.0"
+    "@typescript-eslint/types" "8.61.0"
+    "@typescript-eslint/visitor-keys" "8.61.0"
+    debug "^4.4.3"
+    minimatch "^10.2.2"
+    semver "^7.7.3"
+    tinyglobby "^0.2.15"
+    ts-api-utils "^2.5.0"
+
+"@typescript-eslint/utils@8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.61.0.tgz#ed3546a052787e84ea6c5064d0919fc5eea8522f"
+  integrity sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.9.1"
+    "@typescript-eslint/scope-manager" "8.61.0"
+    "@typescript-eslint/types" "8.61.0"
+    "@typescript-eslint/typescript-estree" "8.61.0"
+
+"@typescript-eslint/visitor-keys@8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz#39b4e1ab8936d23bea973d39fd092f9aa21f275e"
+  integrity sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==
+  dependencies:
+    "@typescript-eslint/types" "8.61.0"
+    eslint-visitor-keys "^5.0.0"
 
 "@ungap/structured-clone@^1.2.0":
   version "1.2.0"
@@ -924,11 +940,6 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-regex@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
-  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
-
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -947,11 +958,6 @@ ansi-styles@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
-
-ansi-styles@^6.1.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
-  integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
 anymatch@^3.0.3:
   version "3.1.3"
@@ -977,11 +983,6 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
-
-async@^3.2.6:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
-  integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
 
 babel-jest@^29.7.0:
   version "29.7.0"
@@ -1060,20 +1061,6 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
-
-brace-expansion@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
-  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
-  dependencies:
-    balanced-match "^1.0.0"
-
-brace-expansion@^2.0.2:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.1.tgz#c68b1c4111c76aae3a6fba55d496cee10c39dad8"
-  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
-  dependencies:
-    balanced-match "^1.0.0"
 
 brace-expansion@^5.0.5:
   version "5.0.6"
@@ -1251,7 +1238,7 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
+cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -1260,7 +1247,14 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
+debug@^4.1.0, debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
+debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -1304,18 +1298,6 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-eastasianwidth@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
-  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
-
-ejs@^3.1.10:
-  version "3.1.10"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
-  integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
-  dependencies:
-    jake "^10.8.5"
-
 electron-to-chromium@^1.4.530:
   version "1.4.534"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.534.tgz#2056c1fc41a7157cdd5c634f96e758d727b69201"
@@ -1330,11 +1312,6 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-emoji-regex@^9.2.2:
-  version "9.2.2"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
-  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -1364,9 +1341,9 @@ escape-string-regexp@^4.0.0:
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 eslint-config-prettier@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz#31af3d94578645966c082fcb71a5846d3c94867f"
-  integrity sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz#90deb4fa0259592df774b600dbd1d2249a78ce91"
+  integrity sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==
 
 eslint-scope@^7.2.2:
   version "7.2.2"
@@ -1380,6 +1357,11 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
+
+eslint-visitor-keys@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz#9e3c9489697824d2d4ce3a8ad12628f91e9f59be"
+  integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
 
 eslint@^8.56.0:
   version "8.57.1"
@@ -1499,17 +1481,6 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
-  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.4"
-
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -1521,9 +1492,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fastq@^1.6.0:
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.17.1.tgz#2a523f07a4e7b1e81a42b91b8bf2254107753b47"
-  integrity sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.20.1.tgz#ca750a10dc925bc8b18839fd203e3ef4b3ced675"
+  integrity sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==
   dependencies:
     reusify "^1.0.4"
 
@@ -1534,19 +1505,17 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
-
-filelist@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.6.tgz#1e8870942a7c636c862f7c49b9394937b6a995a3"
-  integrity sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==
-  dependencies:
-    minimatch "^5.0.1"
 
 fill-range@^7.1.1:
   version "7.1.1"
@@ -1585,14 +1554,6 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
   integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
-foreground-child@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
-  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
-  dependencies:
-    cross-spawn "^7.0.6"
-    signal-exit "^4.0.1"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1628,13 +1589,6 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
-glob-parent@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
-  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
-  dependencies:
-    is-glob "^4.0.1"
-
 glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
@@ -1642,17 +1596,14 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^11.0.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-11.1.0.tgz#4f826576e4eb99c7dad383793d2f9f08f67e50a6"
-  integrity sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==
+glob@^13.0.3:
+  version "13.0.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-13.0.6.tgz#078666566a425147ccacfbd2e332deb66a2be71d"
+  integrity sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==
   dependencies:
-    foreground-child "^3.3.1"
-    jackspeak "^4.1.1"
-    minimatch "^10.1.1"
-    minipass "^7.1.2"
-    package-json-from-dist "^1.0.0"
-    path-scurry "^2.0.0"
+    minimatch "^10.2.2"
+    minipass "^7.1.3"
+    path-scurry "^2.0.2"
 
 glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
@@ -1687,6 +1638,18 @@ graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
+
+handlebars@^4.7.9:
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
+  integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.2"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -1725,10 +1688,10 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
   integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
 
-ignore@^5.3.1:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
-  integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
+ignore@^7.0.5:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
+  integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
 
 import-fresh@^3.2.1:
   version "3.3.0"
@@ -1791,7 +1754,7 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
+is-glob@^4.0.0, is-glob@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -1875,22 +1838,6 @@ istanbul-reports@^3.1.3:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
-
-jackspeak@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-4.1.1.tgz#96876030f450502047fc7e8c7fcf8ce8124e43ae"
-  integrity sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==
-  dependencies:
-    "@isaacs/cliui" "^8.0.2"
-
-jake@^10.8.5:
-  version "10.9.4"
-  resolved "https://registry.yarnpkg.com/jake/-/jake-10.9.4.tgz#d626da108c63d5cfb00ab5c25fadc7e0084af8e6"
-  integrity sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==
-  dependencies:
-    async "^3.2.6"
-    filelist "^1.0.4"
-    picocolors "^1.1.1"
 
 jest-changed-files@^29.7.0:
   version "29.7.0"
@@ -2192,7 +2139,7 @@ jest-snapshot@^29.7.0:
     pretty-format "^29.7.0"
     semver "^7.5.3"
 
-jest-util@^29.0.0, jest-util@^29.7.0:
+jest-util@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"
   integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
@@ -2360,9 +2307,9 @@ lodash.merge@^4.6.2:
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lru-cache@^11.0.0:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.0.1.tgz#3a732fbfedb82c5ba7bca6564ad3f42afcb6e147"
-  integrity sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==
+  version "11.5.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.5.1.tgz#f3daa3540847b9737ebc02499ddb36765e54db4a"
+  integrity sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -2402,11 +2349,6 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.3.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
-  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
-
 micromatch@^4.0.4:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
@@ -2420,7 +2362,7 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@^10.1.1:
+minimatch@^10.2.2:
   version "10.2.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
   integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
@@ -2434,39 +2376,40 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1:
-  version "5.1.9"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.9.tgz#1293ef15db0098b394540e8f9f744f9fda8dee4b"
-  integrity sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==
-  dependencies:
-    brace-expansion "^2.0.1"
+minimist@^1.2.5:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-minimatch@^9.0.4:
-  version "9.0.9"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
-  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
-  dependencies:
-    brace-expansion "^2.0.2"
-
-minipass@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
-  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
+minipass@^7.1.2, minipass@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+neo-async@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
 nock@^13.5.5:
-  version "13.5.5"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-13.5.5.tgz#cd1caaca281d42be17d51946367a3d53a6af3e78"
-  integrity sha512-XKYnqUrCwXC8DGG1xX4YH5yNIrlh9c065uaMZZHUoeUUINTOyt+x/G+ezYk0Ft6ExSREVIs+qBJDK503viTfFA==
+  version "13.5.6"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.5.6.tgz#5e693ec2300bbf603b61dae6df0225673e6c4997"
+  integrity sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==
   dependencies:
     debug "^4.1.0"
     json-stringify-safe "^5.0.1"
@@ -2553,10 +2496,10 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-package-json-from-dist@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz#e501cd3094b278495eb4258d4c9f6d5ac3019f00"
-  integrity sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==
+package-json-from-dist@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -2595,10 +2538,10 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-scurry@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-2.0.0.tgz#9f052289f23ad8bf9397a2a0425e7b8615c58580"
-  integrity sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==
+path-scurry@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-2.0.2.tgz#6be0d0ee02a10d9e0de7a98bae65e182c9061f85"
+  integrity sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==
   dependencies:
     lru-cache "^11.0.0"
     minipass "^7.1.2"
@@ -2617,6 +2560,11 @@ picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
+
+picomatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 pirates@^4.0.4:
   version "4.0.6"
@@ -2673,9 +2621,9 @@ queue-microtask@^1.2.2:
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
 react-is@^18.0.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
-  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 "readable-stream@>=1.0.33-1 <1.1.0-0":
   version "1.0.34"
@@ -2734,9 +2682,9 @@ resolve@^1.20.0:
     supports-preserve-symlinks-flag "^1.0.0"
 
 reusify@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
-  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
+  integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
 
 rimraf@^3.0.2:
   version "3.0.2"
@@ -2746,12 +2694,12 @@ rimraf@^3.0.2:
     glob "^7.1.3"
 
 rimraf@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-6.0.1.tgz#ffb8ad8844dd60332ab15f52bc104bc3ed71ea4e"
-  integrity sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-6.1.3.tgz#afbee236b3bd2be331d4e7ce4493bac1718981af"
+  integrity sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==
   dependencies:
-    glob "^11.0.0"
-    package-json-from-dist "^1.0.0"
+    glob "^13.0.3"
+    package-json-from-dist "^1.0.1"
 
 run-parallel@^1.1.9:
   version "1.2.0"
@@ -2765,10 +2713,10 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.8, semver@^7.6.0, semver@^7.6.3:
-  version "7.6.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
-  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
+semver@^7.3.8, semver@^7.7.3, semver@^7.8.0:
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.4.tgz#c73eceebae0616934be8dff28a7fd70757c8e696"
+  integrity sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==
 
 semver@^7.5.3, semver@^7.5.4:
   version "7.6.0"
@@ -2793,11 +2741,6 @@ signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
-
-signal-exit@^4.0.1:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
-  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
 sisteransi@^1.0.5:
   version "1.0.5"
@@ -2847,15 +2790,6 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -2865,26 +2799,10 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^5.0.1, string-width@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
-  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
-  dependencies:
-    eastasianwidth "^0.2.0"
-    emoji-regex "^9.2.2"
-    strip-ansi "^7.0.1"
-
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
   integrity sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==
-
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -2892,13 +2810,6 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
-
-strip-ansi@^7.0.1:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45"
-  integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
-  dependencies:
-    ansi-regex "^6.0.1"
 
 strip-bom@^4.0.0:
   version "4.0.0"
@@ -2963,6 +2874,14 @@ through2@^0.6.3:
     readable-stream ">=1.0.33-1 <1.1.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
+tinyglobby@^0.2.15:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
+
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
@@ -2980,24 +2899,24 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-ts-api-utils@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.3.0.tgz#4b490e27129f1e8e686b45cc4ab63714dc60eea1"
-  integrity sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==
+ts-api-utils@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.5.0.tgz#4acd4a155e22734990a5ed1fe9e97f113bcb37c1"
+  integrity sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==
 
 ts-jest@^29.2.5:
-  version "29.2.5"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.2.5.tgz#591a3c108e1f5ebd013d3152142cb5472b399d63"
-  integrity sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==
+  version "29.4.11"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.4.11.tgz#42f5de21c37ccc01a580253afae6955abbf4d0b3"
+  integrity sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==
   dependencies:
     bs-logger "^0.2.6"
-    ejs "^3.1.10"
     fast-json-stable-stringify "^2.1.0"
-    jest-util "^29.0.0"
+    handlebars "^4.7.9"
     json5 "^2.2.3"
     lodash.memoize "^4.1.2"
     make-error "^1.3.6"
-    semver "^7.6.3"
+    semver "^7.8.0"
+    type-fest "^4.41.0"
     yargs-parser "^21.1.1"
 
 ts-node@^10.9.2:
@@ -3041,20 +2960,30 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
+type-fest@^4.41.0:
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
+  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
+
 typescript@^5.6.2:
-  version "5.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
-  integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
-undici-types@~5.26.4:
-  version "5.26.5"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
-  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+uglify-js@^3.1.4:
+  version "3.19.3"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.19.3.tgz#82315e9bbc6f2b25888858acd1fff8441035b77f"
+  integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
 
-undici-types@~6.19.2:
-  version "6.19.8"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
-  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
+"undici-types@>=7.24.0 <7.24.7":
+  version "7.24.6"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
+  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 update-browserslist-db@^1.0.13:
   version "1.0.13"
@@ -3099,14 +3028,10 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
@@ -3116,15 +3041,6 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
-
-wrap-ansi@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
-  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
-  dependencies:
-    ansi-styles "^6.1.0"
-    string-width "^5.0.1"
-    strip-ansi "^7.0.1"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
# Issue

Fixes #113.

## Details

1. Tracks VO actions more carefully with logic to prevent new actions once a `.stop()` has been triggered and await in-flight actions before triggering the process kill
2. Layered approach to stopping VO as the process `kill` is unreliable

## CheckList

- [x] Has been tested (where required).
