### PR TITLE
fix: improved stop for NVDA and VoiceOver

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -32,10 +32,9 @@ module.exports = {
     "<rootDir>/src/macOS/VoiceOver/constants.ts",
     "<rootDir>/src/macOS/VoiceOver/Containments.ts",
     "<rootDir>/src/macOS/VoiceOver/Directions.ts",
-    // TODO: flesh out VoiceOverClient tests
-    "<rootDir>/src/macOS/VoiceOver/VoiceOverClient.ts",
     "<rootDir>/src/macOS/VoiceOver/Places.ts",
     "<rootDir>/src/windows/NVDA/keyCodeCommands.ts",
+    // TODO: coverage needed for NVDA
     "<rootDir>/src/windows/NVDA/NVDA.ts",
     "<rootDir>/src/windows/NVDA/NVDAClient.ts",
   ],

--- a/src/macOS/VoiceOver/VoiceOver.test.ts
+++ b/src/macOS/VoiceOver/VoiceOver.test.ts
@@ -803,4 +803,95 @@ describe("VoiceOver", () => {
       expect(VoiceOverCaptionStub.clearItemTextLog).toHaveBeenCalled();
     });
   });
+
+  describe("when stop is in progress", () => {
+    let stopPromise: Promise<void>;
+    let resolveTerminate: () => void;
+
+    beforeEach(async () => {
+      jest.mocked(isMacOS).mockReturnValue(true);
+      const resetSettingsSpy = jest.fn();
+      jest.mocked(storeOriginalSettings).mockResolvedValue(resetSettingsSpy);
+
+      jest.mocked(terminateVoiceOverProcess).mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveTerminate = resolve;
+          }),
+      );
+
+      await vo.start();
+
+      jest.clearAllMocks();
+
+      stopPromise = vo.stop();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    afterEach(async () => {
+      resolveTerminate();
+      await stopPromise;
+    });
+
+    it("should throw when calling previous", async () => {
+      await expect(async () => await vo.previous()).rejects.toThrow(
+        ERR_VOICE_OVER_NOT_RUNNING,
+      );
+    });
+
+    it("should throw when calling next", async () => {
+      await expect(async () => await vo.next()).rejects.toThrow(
+        ERR_VOICE_OVER_NOT_RUNNING,
+      );
+    });
+
+    it("should throw when calling act", async () => {
+      await expect(async () => await vo.act()).rejects.toThrow(
+        ERR_VOICE_OVER_NOT_RUNNING,
+      );
+    });
+
+    it("should throw when calling interact", async () => {
+      await expect(async () => await vo.interact()).rejects.toThrow(
+        ERR_VOICE_OVER_NOT_RUNNING,
+      );
+    });
+
+    it("should throw when calling stopInteracting", async () => {
+      await expect(async () => await vo.stopInteracting()).rejects.toThrow(
+        ERR_VOICE_OVER_NOT_RUNNING,
+      );
+    });
+
+    it("should throw when calling perform", async () => {
+      await expect(
+        async () => await vo.perform(CommanderCommands.ACTIONS),
+      ).rejects.toThrow(ERR_VOICE_OVER_NOT_RUNNING);
+    });
+
+    it("should throw when calling press", async () => {
+      await expect(async () => await vo.press("return")).rejects.toThrow(
+        ERR_VOICE_OVER_NOT_RUNNING,
+      );
+    });
+
+    it("should throw when calling lastSpokenPhrase", async () => {
+      await expect(async () => await vo.lastSpokenPhrase()).rejects.toThrow(
+        ERR_VOICE_OVER_NOT_RUNNING,
+      );
+    });
+
+    it("should throw when calling spokenPhraseLog", async () => {
+      await expect(async () => await vo.spokenPhraseLog()).rejects.toThrow(
+        ERR_VOICE_OVER_NOT_RUNNING,
+      );
+    });
+
+    it("should throw when calling itemText", async () => {
+      await expect(async () => await vo.itemText()).rejects.toThrow(
+        ERR_VOICE_OVER_NOT_RUNNING,
+      );
+    });
+  });
 });

--- a/src/macOS/VoiceOver/VoiceOverClient.test.ts
+++ b/src/macOS/VoiceOver/VoiceOverClient.test.ts
@@ -1,4 +1,5 @@
 import { cleanSpokenPhrase } from "./cleanSpokenPhrase";
+import { ERR_VOICE_OVER_NOT_RUNNING } from "../errors";
 import { itemText } from "./itemText";
 import { lastSpokenPhrase } from "./lastSpokenPhrase";
 import { MAX_SPOKEN_PHRASES_POLL_COUNT } from "./constants";
@@ -358,6 +359,16 @@ describe("VoiceOverClient", () => {
 
     it("should return with an empty string as the last spoken phrase if not yet acted", async () => {
       expect(await voiceOverClient.lastSpokenPhrase()).toEqual("");
+    });
+
+    it("should gracefully handle clearing the spoken phrase log when there have been no spoken phrases", async () => {
+      await expect(
+        voiceOverClient.clearSpokenPhraseLog(),
+      ).resolves.not.toThrow();
+    });
+
+    it("should gracefully handle clearing the item text log when there have been no spoken phrases", async () => {
+      await expect(voiceOverClient.clearItemTextLog()).resolves.not.toThrow();
     });
 
     describe("when enqueueAndTap is called on an action with no capture options", () => {
@@ -743,6 +754,296 @@ describe("VoiceOverClient", () => {
         it("should not return the last spoken phrase from the last action", async () => {
           expect(await voiceOverClient.lastSpokenPhrase()).toEqual("");
         });
+      });
+    });
+  });
+
+  describe("when multiple actions are enqueued", () => {
+    let voiceOverClientWithCapture: VoiceOverClient;
+
+    beforeEach(() => {
+      voiceOverClientWithCapture = new VoiceOverClient({ capture: true });
+    });
+
+    it("should execute actions serially and accumulate logs", async () => {
+      const result1 = Symbol("result-1");
+      const result2 = Symbol("result-2");
+      const result3 = Symbol("result-3");
+
+      const promise1 = voiceOverClientWithCapture.enqueueAndTap(async () => {
+        return result1;
+      });
+
+      const promise2 = voiceOverClientWithCapture.enqueueAndTap(async () => {
+        return result2;
+      });
+
+      const promise3 = voiceOverClientWithCapture.enqueueAndTap(async () => {
+        return result3;
+      });
+
+      const [r1, r2, r3] = await Promise.all([promise1, promise2, promise3]);
+
+      expect(r1).toBe(result1);
+      expect(r2).toBe(result2);
+      expect(r3).toBe(result3);
+
+      expect(await voiceOverClientWithCapture.itemTextLog()).toEqual([
+        `cleaned_${itemTextDummy}`,
+        `cleaned_${itemTextDummy}`,
+        `cleaned_${itemTextDummy}`,
+      ]);
+
+      expect(await voiceOverClientWithCapture.spokenPhraseLog()).toEqual([
+        `cleaned_${lastSpokenPhraseDummy}`,
+        `cleaned_${lastSpokenPhraseDummy}`,
+        `cleaned_${lastSpokenPhraseDummy}`,
+      ]);
+    });
+
+    it("should allow accessing logs while actions are in flight", async () => {
+      let actionStarted = false;
+      let resolveAction!: () => void;
+
+      const action = async () => {
+        actionStarted = true;
+
+        await new Promise<void>((resolve) => {
+          resolveAction = resolve;
+        });
+      };
+
+      voiceOverClientWithCapture.enqueueAndTap(action);
+
+      await new Promise((resolve) => {
+        const checkInterval = setInterval(() => {
+          if (actionStarted) {
+            clearInterval(checkInterval);
+            resolve(undefined);
+          }
+        }, 10);
+      });
+
+      resolveAction();
+
+      const itemLogs = await voiceOverClientWithCapture.itemTextLog();
+      const spokenLogs = await voiceOverClientWithCapture.spokenPhraseLog();
+
+      expect(itemLogs).toEqual([`cleaned_${itemTextDummy}`]);
+      expect(spokenLogs).toEqual([`cleaned_${lastSpokenPhraseDummy}`]);
+    });
+  });
+
+  describe("when an enqueued action throws an error", () => {
+    let voiceOverClientWithCapture: VoiceOverClient;
+
+    beforeEach(() => {
+      voiceOverClientWithCapture = new VoiceOverClient({ capture: true });
+    });
+
+    it("should reject the action's promise", async () => {
+      const testError = new Error("test-action-error");
+
+      const promise = voiceOverClientWithCapture.enqueueAndTap(async () => {
+        throw testError;
+      });
+
+      await expect(promise).rejects.toBe(testError);
+    });
+
+    it("should not log the failed action and continue processing subsequent actions", async () => {
+      const testError = new Error("test-action-error");
+      const successResult = Symbol("success-result");
+
+      const rejectingPromise = voiceOverClientWithCapture.enqueueAndTap(
+        async () => {
+          throw testError;
+        },
+      );
+
+      const successPromise = voiceOverClientWithCapture.enqueueAndTap(
+        async () => successResult,
+      );
+
+      await expect(rejectingPromise).rejects.toBe(testError);
+      const result = await successPromise;
+
+      expect(result).toBe(successResult);
+
+      // Only the successful action should be logged
+      expect(await voiceOverClientWithCapture.itemTextLog()).toEqual([
+        `cleaned_${itemTextDummy}`,
+      ]);
+
+      expect(await voiceOverClientWithCapture.spokenPhraseLog()).toEqual([
+        `cleaned_${lastSpokenPhraseDummy}`,
+      ]);
+    });
+
+    it("should not log when an action errors and capture is disabled", async () => {
+      const testError = new Error("test-action-error");
+
+      const promise = voiceOverClientWithCapture.enqueueAndTap(
+        async () => {
+          throw testError;
+        },
+        { capture: false },
+      );
+
+      await expect(promise).rejects.toBe(testError);
+
+      expect(await voiceOverClientWithCapture.itemTextLog()).toHaveLength(0);
+      expect(await voiceOverClientWithCapture.spokenPhraseLog()).toHaveLength(
+        0,
+      );
+    });
+  });
+
+  describe("stop", () => {
+    describe("when there is something in flight", () => {
+      let voiceOverClientWithCapture: VoiceOverClient;
+      let actionStarted: boolean;
+      let resolveInFlightAction: () => void;
+
+      beforeEach(async () => {
+        voiceOverClientWithCapture = new VoiceOverClient({ capture: true });
+        actionStarted = false;
+
+        const inFlightAction = async () => {
+          actionStarted = true;
+
+          await new Promise<void>((resolve) => {
+            resolveInFlightAction = resolve;
+          });
+        };
+
+        voiceOverClientWithCapture.enqueueAndTap(inFlightAction);
+
+        await new Promise((resolve) => {
+          const checkInterval = setInterval(() => {
+            if (actionStarted) {
+              clearInterval(checkInterval);
+              resolve(undefined);
+            }
+          }, 10);
+        });
+      });
+
+      it("should wait for the in-flight action to complete before resolving", async () => {
+        const stopPromise = voiceOverClientWithCapture.stop();
+
+        let stopResolved = false;
+        stopPromise.then(() => {
+          stopResolved = true;
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(stopResolved).toBe(false);
+
+        resolveInFlightAction();
+
+        await stopPromise;
+
+        expect(stopResolved).toBe(true);
+      });
+    });
+
+    describe("when there is something in flight and something queued", () => {
+      let voiceOverClientWithCapture: VoiceOverClient;
+      let inFlightActionStarted: boolean;
+      let resolveInFlightAction: () => void;
+      let queuedAction1Error!: Error;
+      let queuedAction2Error!: Error;
+
+      beforeEach(async () => {
+        voiceOverClientWithCapture = new VoiceOverClient({ capture: true });
+        inFlightActionStarted = false;
+
+        const inFlightAction = async () => {
+          inFlightActionStarted = true;
+
+          await new Promise<void>((resolve) => {
+            resolveInFlightAction = resolve;
+          });
+        };
+
+        const queuedAction1 = async () => {};
+        const queuedAction2 = async () => {};
+
+        voiceOverClientWithCapture
+          .enqueueAndTap(inFlightAction)
+          .catch(() => {});
+        voiceOverClientWithCapture.enqueueAndTap(queuedAction1).catch((e) => {
+          queuedAction1Error = e;
+        });
+        voiceOverClientWithCapture.enqueueAndTap(queuedAction2).catch((e) => {
+          queuedAction2Error = e;
+        });
+
+        await new Promise((resolve) => {
+          const checkInterval = setInterval(() => {
+            if (inFlightActionStarted) {
+              clearInterval(checkInterval);
+              resolve(undefined);
+            }
+          }, 10);
+        });
+      });
+
+      it("should wait for the in-flight action and queued actions to resolve and/or reject before resolving", async () => {
+        const stopPromise = voiceOverClientWithCapture.stop();
+
+        let stopResolved = false;
+        stopPromise.then(() => {
+          stopResolved = true;
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(stopResolved).toBe(false);
+
+        resolveInFlightAction();
+
+        await stopPromise;
+
+        expect(stopResolved).toBe(true);
+        expect(queuedAction1Error).toEqual(
+          new Error(ERR_VOICE_OVER_NOT_RUNNING),
+        );
+        expect(queuedAction2Error).toEqual(
+          new Error(ERR_VOICE_OVER_NOT_RUNNING),
+        );
+      });
+    });
+
+    describe("when enqueueAndTap is called after stop", () => {
+      let voiceOverClientWithCapture: VoiceOverClient;
+
+      beforeEach(async () => {
+        voiceOverClientWithCapture = new VoiceOverClient({ capture: true });
+        await voiceOverClientWithCapture.stop();
+      });
+
+      it("should throw ERR_VOICE_OVER_NOT_RUNNING", async () => {
+        const promise = voiceOverClientWithCapture.enqueueAndTap(async () => {
+          return Symbol("action-result");
+        });
+
+        await expect(promise).rejects.toThrow(ERR_VOICE_OVER_NOT_RUNNING);
+      });
+
+      it("should throw ERR_VOICE_OVER_NOT_RUNNING for all subsequent calls", async () => {
+        const promise1 = voiceOverClientWithCapture.enqueueAndTap(async () => {
+          return Symbol("action-result-1");
+        });
+
+        const promise2 = voiceOverClientWithCapture.enqueueAndTap(async () => {
+          return Symbol("action-result-2");
+        });
+
+        await expect(promise1).rejects.toThrow(ERR_VOICE_OVER_NOT_RUNNING);
+        await expect(promise2).rejects.toThrow(ERR_VOICE_OVER_NOT_RUNNING);
       });
     });
   });

--- a/src/macOS/VoiceOver/VoiceOverClient.ts
+++ b/src/macOS/VoiceOver/VoiceOverClient.ts
@@ -29,7 +29,7 @@ interface QueueAction {
 }
 
 export class VoiceOverClient {
-  #inFlight = false;
+  #inFlight: Promise<unknown> | null = null;
   #queue: QueueAction[] = [];
   #stopped = false;
   #capture: CommandOptions["capture"];
@@ -47,7 +47,7 @@ export class VoiceOverClient {
   async stop(): Promise<void> {
     this.#stopped = true;
 
-    await Promise.allSettled(this.#queue.map(({ promise }) => promise));
+    await this.#waitForAllActions();
   }
 
   /**
@@ -74,9 +74,7 @@ export class VoiceOverClient {
    * @returns {Promise<string[]>} The item text log.
    */
   async itemTextLog(): Promise<string[]> {
-    while (this.#inFlight) {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
+    await this.#waitForAllActions();
 
     return this.#itemTextLogStore;
   }
@@ -85,9 +83,7 @@ export class VoiceOverClient {
    * Clear the item text log.
    */
   async clearItemTextLog(): Promise<void> {
-    while (this.#inFlight) {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
+    await this.#waitForAllActions();
 
     this.#itemTextLogStore = [];
   }
@@ -98,9 +94,7 @@ export class VoiceOverClient {
    * @returns {Promise<string[]>} The spoken phrase log.
    */
   async spokenPhraseLog(): Promise<string[]> {
-    while (this.#inFlight) {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
+    await this.#waitForAllActions();
 
     return this.#spokenPhraseLogStore;
   }
@@ -109,9 +103,7 @@ export class VoiceOverClient {
    * Clear the spoken phrase log.
    */
   async clearSpokenPhraseLog(): Promise<void> {
-    while (this.#inFlight) {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
+    await this.#waitForAllActions();
 
     // Keep a reference to the last spoken phrase so we can continue to use the
     // same change detection technique.
@@ -128,8 +120,8 @@ export class VoiceOverClient {
    * @param {object} options Additional options.
    * @returns {Promise<T>} Promise that resolves with the action's result.
    */
-  async enqueueAndTap<T, S extends Promise<T>>(
-    action: () => S,
+  async enqueueAndTap<T>(
+    action: () => Promise<T>,
     options?: Pick<CommandOptions, "capture">,
   ): Promise<T> {
     if (this.#stopped) {
@@ -149,13 +141,23 @@ export class VoiceOverClient {
     return promise;
   }
 
+  async #waitForAllActions(): Promise<void> {
+    const allPromises = this.#queue.map(({ promise }) => promise);
+
+    if (this.#inFlight) {
+      allPromises.push(this.#inFlight);
+    }
+
+    await Promise.allSettled(allPromises);
+  }
+
   async #processQueue() {
     if (this.#inFlight || this.#queue.length === 0) {
       return;
     }
 
-    this.#inFlight = true;
-    const { action, options, resolve, reject } = this.#queue.shift()!;
+    const { action, options, resolve, reject, promise } = this.#queue.shift()!;
+    this.#inFlight = promise;
 
     try {
       if (this.#stopped) {
@@ -178,7 +180,7 @@ export class VoiceOverClient {
     } catch (error) {
       reject(error);
     } finally {
-      this.#inFlight = false;
+      this.#inFlight = null;
       this.#processQueue();
     }
   }

--- a/src/windows/NVDA/NVDA.test.ts
+++ b/src/windows/NVDA/NVDA.test.ts
@@ -1,0 +1,325 @@
+import { ERR_NVDA_ALREADY_RUNNING, ERR_NVDA_NOT_RUNNING } from "../errors";
+import { isNVDAInstalled } from "./isNVDAInstalled";
+import { isWindows } from "../isWindows";
+import { NVDA } from "./NVDA";
+import { NVDAClient } from "./NVDAClient";
+import { quit } from "./quit";
+import { start } from "./start";
+
+jest.mock("./isNVDAInstalled", () => ({
+  isNVDAInstalled: jest.fn(),
+}));
+jest.mock("../isWindows", () => ({
+  isWindows: jest.fn(),
+}));
+jest.mock("./NVDAClient", () => ({
+  NVDAClient: jest.fn(),
+}));
+jest.mock("./quit", () => ({
+  quit: jest.fn(),
+}));
+jest.mock("./start", () => ({
+  start: jest.fn(),
+}));
+
+const NVDAClientStub = {
+  connect: jest.fn(),
+  stop: jest.fn(),
+  sendKeyCode: jest.fn(),
+  enqueueAndTap: jest.fn(),
+  spokenPhraseLog: jest.fn(),
+  clearSpokenPhraseLog: jest.fn(),
+} as unknown as NVDAClient;
+
+describe("NVDA", () => {
+  let nvda: NVDA;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(isWindows).mockReturnValue(true);
+    jest.mocked(isNVDAInstalled).mockResolvedValue(true);
+    jest.mocked(NVDAClientStub.connect).mockResolvedValue(undefined);
+    jest.mocked(NVDAClient).mockImplementation(() => NVDAClientStub);
+  });
+
+  describe("detect", () => {
+    describe("when Windows and NVDA is installed", () => {
+      it("should return true", async () => {
+        nvda = new NVDA();
+
+        const result = await nvda.detect();
+
+        expect(result).toBe(true);
+      });
+    });
+
+    describe("when Windows and NVDA is not installed", () => {
+      beforeEach(() => {
+        jest.mocked(isNVDAInstalled).mockResolvedValue(false);
+      });
+
+      it("should return false", async () => {
+        nvda = new NVDA();
+
+        const result = await nvda.detect();
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe("when not Windows", () => {
+      beforeEach(() => {
+        jest.mocked(isWindows).mockReturnValue(false);
+      });
+
+      it("should return false", async () => {
+        nvda = new NVDA();
+
+        const result = await nvda.detect();
+
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe("start", () => {
+    beforeEach(() => {
+      nvda = new NVDA();
+    });
+
+    describe("when NVDA is not already running", () => {
+      it("should start NVDA", async () => {
+        await nvda.start();
+
+        expect(start).toHaveBeenCalled();
+      });
+    });
+
+    describe("when NVDA is already running", () => {
+      beforeEach(async () => {
+        jest.mocked(start).mockResolvedValue(undefined);
+
+        await nvda.start();
+
+        jest.clearAllMocks();
+      });
+
+      it("should throw an error", async () => {
+        await expect(async () => await nvda.start()).rejects.toThrow(
+          ERR_NVDA_ALREADY_RUNNING,
+        );
+      });
+    });
+  });
+
+  describe("stop", () => {
+    beforeEach(() => {
+      nvda = new NVDA();
+    });
+
+    describe("when NVDA is not running", () => {
+      it("should throw an error", async () => {
+        await expect(async () => await nvda.stop()).rejects.toThrow(
+          ERR_NVDA_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe("when NVDA is running", () => {
+      beforeEach(async () => {
+        jest.mocked(start).mockResolvedValue(undefined);
+        jest.mocked(quit).mockResolvedValue(undefined);
+
+        await nvda.start();
+
+        jest.clearAllMocks();
+
+        await nvda.stop();
+      });
+
+      it("should stop the client", () => {
+        expect(NVDAClientStub.stop).toHaveBeenCalled();
+      });
+
+      it("should quit NVDA", () => {
+        expect(quit).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("previous", () => {
+    beforeEach(() => {
+      nvda = new NVDA();
+    });
+
+    describe("when NVDA is not running", () => {
+      it("should throw an error", async () => {
+        await expect(async () => await nvda.previous()).rejects.toThrow(
+          ERR_NVDA_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe("when NVDA is running", () => {
+      beforeEach(async () => {
+        jest.mocked(start).mockResolvedValue(undefined);
+
+        await nvda.start();
+
+        jest.clearAllMocks();
+
+        await nvda.previous();
+      });
+
+      it("should enqueue a key press command", () => {
+        expect(NVDAClientStub.enqueueAndTap).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("next", () => {
+    beforeEach(() => {
+      nvda = new NVDA();
+    });
+
+    describe("when NVDA is not running", () => {
+      it("should throw an error", async () => {
+        await expect(async () => await nvda.next()).rejects.toThrow(
+          ERR_NVDA_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe("when NVDA is running", () => {
+      beforeEach(async () => {
+        jest.mocked(start).mockResolvedValue(undefined);
+
+        await nvda.start();
+
+        jest.clearAllMocks();
+
+        await nvda.next();
+      });
+
+      it("should enqueue a key press command", () => {
+        expect(NVDAClientStub.enqueueAndTap).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("spokenPhraseLog", () => {
+    beforeEach(() => {
+      nvda = new NVDA();
+    });
+
+    describe("when NVDA is not running", () => {
+      it("should throw an error", async () => {
+        await expect(async () => await nvda.spokenPhraseLog()).rejects.toThrow(
+          ERR_NVDA_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe("when NVDA is running", () => {
+      beforeEach(async () => {
+        jest.mocked(start).mockResolvedValue(undefined);
+
+        await nvda.start();
+
+        jest.clearAllMocks();
+
+        await nvda.spokenPhraseLog();
+      });
+
+      it("should call the client's spokenPhraseLog method", () => {
+        expect(NVDAClientStub.spokenPhraseLog).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("clearSpokenPhraseLog", () => {
+    beforeEach(() => {
+      nvda = new NVDA();
+    });
+
+    describe("when NVDA is not running", () => {
+      it("should throw an error", async () => {
+        await expect(
+          async () => await nvda.clearSpokenPhraseLog(),
+        ).rejects.toThrow(ERR_NVDA_NOT_RUNNING);
+      });
+    });
+
+    describe("when NVDA is running", () => {
+      beforeEach(async () => {
+        jest.mocked(start).mockResolvedValue(undefined);
+
+        await nvda.start();
+
+        jest.clearAllMocks();
+
+        await nvda.clearSpokenPhraseLog();
+      });
+
+      it("should call the client's clearSpokenPhraseLog method", () => {
+        expect(NVDAClientStub.clearSpokenPhraseLog).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("when stop is in progress", () => {
+    let stopPromise: Promise<void>;
+    let resolveQuit: () => void;
+
+    beforeEach(async () => {
+      nvda = new NVDA();
+
+      jest.mocked(start).mockResolvedValue(undefined);
+
+      jest.mocked(quit).mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveQuit = resolve;
+          }),
+      );
+
+      await nvda.start();
+
+      jest.clearAllMocks();
+
+      stopPromise = nvda.stop();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    afterEach(async () => {
+      resolveQuit();
+      await stopPromise;
+    });
+
+    it("should throw when calling previous", async () => {
+      await expect(async () => await nvda.previous()).rejects.toThrow(
+        ERR_NVDA_NOT_RUNNING,
+      );
+    });
+
+    it("should throw when calling next", async () => {
+      await expect(async () => await nvda.next()).rejects.toThrow(
+        ERR_NVDA_NOT_RUNNING,
+      );
+    });
+
+    it("should throw when calling spokenPhraseLog", async () => {
+      await expect(async () => await nvda.spokenPhraseLog()).rejects.toThrow(
+        ERR_NVDA_NOT_RUNNING,
+      );
+    });
+
+    it("should throw when calling clearSpokenPhraseLog", async () => {
+      await expect(
+        async () => await nvda.clearSpokenPhraseLog(),
+      ).rejects.toThrow(ERR_NVDA_NOT_RUNNING);
+    });
+  });
+});

--- a/src/windows/NVDA/NVDA.ts
+++ b/src/windows/NVDA/NVDA.ts
@@ -36,6 +36,11 @@ export class NVDA implements ScreenReader {
   #started = false;
 
   /**
+   * NVDA stopping status.
+   */
+  #stopping = false;
+
+  /**
    * Getter for all NVDA keyboard commands.
    *
    * Use with the NVDA `perform` command to invoke a keyboard action:
@@ -161,16 +166,19 @@ export class NVDA implements ScreenReader {
    * ```
    */
   async stop(): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
-    this.#client.disconnect();
+    this.#stopping = true;
+
+    await this.#client.stop();
     this.#client = null;
 
     await quit();
 
     this.#started = false;
+    this.#stopping = false;
   }
 
   /**
@@ -194,13 +202,13 @@ export class NVDA implements ScreenReader {
    * ```
    */
   async previous(options?: CaptureCommandOptions): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
-    return this.#client.waitForSpokenPhrase(
+    return this.#client.enqueueAndTap(
       () => this.#client.sendKeyCode(keyCodeCommands.moveToPrevious),
-      options
+      options,
     );
   }
 
@@ -225,13 +233,13 @@ export class NVDA implements ScreenReader {
    * ```
    */
   async next(options?: CaptureCommandOptions): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
-    return this.#client.waitForSpokenPhrase(
+    return this.#client.enqueueAndTap(
       () => this.#client.sendKeyCode(keyCodeCommands.moveToNext),
-      options
+      options,
     );
   }
 
@@ -259,13 +267,13 @@ export class NVDA implements ScreenReader {
    * ```
    */
   async act(options?: CaptureCommandOptions): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
-    return this.#client.waitForSpokenPhrase(
+    return this.#client.enqueueAndTap(
       () => this.#client.sendKeyCode(keyCodeCommands.activate),
-      options
+      options,
     );
   }
 
@@ -276,7 +284,7 @@ export class NVDA implements ScreenReader {
    * with the item in the NVDA cursor.
    */
   async interact(): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
@@ -290,7 +298,7 @@ export class NVDA implements ScreenReader {
    * with the item in the NVDA cursor.
    */
   async stopInteracting(): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
@@ -339,13 +347,13 @@ export class NVDA implements ScreenReader {
    * @param {string} key Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
    */
   async press(key: string, options?: CaptureCommandOptions): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
     return this.perform(
       parseKey<KeyCodeCommand>(key, Modifiers, KeyCodes),
-      options
+      options,
     );
   }
 
@@ -373,13 +381,13 @@ export class NVDA implements ScreenReader {
    * @param {string} text Text to type into the focused item.
    */
   async type(text: string, options?: CaptureCommandOptions): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
-    return this.#client.waitForSpokenPhrase(
+    return this.#client.enqueueAndTap(
       () => sendKeys({ characters: text }),
-      options
+      options,
     );
   }
 
@@ -410,15 +418,15 @@ export class NVDA implements ScreenReader {
    */
   async perform(
     command: KeyCodeCommand,
-    options?: CaptureCommandOptions
+    options?: CaptureCommandOptions,
   ): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
-    return this.#client.waitForSpokenPhrase(
+    return this.#client.enqueueAndTap(
       () => this.#client.sendKeyCode(command),
-      options
+      options,
     );
   }
 
@@ -449,7 +457,7 @@ export class NVDA implements ScreenReader {
    * @param {object} [options] Click options.
    */
   async click(options?: ClickOptions): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
@@ -458,14 +466,14 @@ export class NVDA implements ScreenReader {
         ? keyCodeCommands.rightMouseClick
         : keyCodeCommands.leftMouseClick;
 
-    await this.#client.waitForSpokenPhrase(
+    await this.#client.enqueueAndTap(
       () =>
         Promise.all(
           [...new Array(options.clickCount ?? 1)].map(() =>
-            this.#client.sendKeyCode(command)
-          )
+            this.#client.sendKeyCode(command),
+          ),
         ),
-      options
+      options,
     );
   }
 
@@ -494,7 +502,7 @@ export class NVDA implements ScreenReader {
    * @returns {string} The last spoken phrase.
    */
   async lastSpokenPhrase(): Promise<string> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
@@ -531,7 +539,7 @@ export class NVDA implements ScreenReader {
    * @returns {Promise<string>} The last spoken phrase.
    */
   async itemText(): Promise<string> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
@@ -565,7 +573,7 @@ export class NVDA implements ScreenReader {
    * @returns {Promise<string[]>} The spoken phrase log.
    */
   async spokenPhraseLog(): Promise<string[]> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
@@ -593,7 +601,7 @@ export class NVDA implements ScreenReader {
    * ```
    */
   async clearSpokenPhraseLog(): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
@@ -631,7 +639,7 @@ export class NVDA implements ScreenReader {
    * @returns {Promise<string[]>} The spoken phrase log.
    */
   async itemTextLog(): Promise<string[]> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
@@ -663,7 +671,7 @@ export class NVDA implements ScreenReader {
    * @alias clearSpokenPhraseLog
    */
   async clearItemTextLog(): Promise<void> {
-    if (!this.#started) {
+    if (!this.#started || this.#stopping) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 

--- a/src/windows/NVDA/NVDAClient.test.ts
+++ b/src/windows/NVDA/NVDAClient.test.ts
@@ -39,7 +39,7 @@ describe("NVDAClient", () => {
           "remote",
           "globalPlugins",
           "remoteClient",
-          "server.pem"
+          "server.pem",
         )
       ) {
         return readKey("server.pem");
@@ -89,7 +89,7 @@ describe("NVDAClient", () => {
           if (++counter === expectedMessages) {
             resolve();
           }
-        })
+        }),
       );
     }
 
@@ -117,7 +117,7 @@ describe("NVDAClient", () => {
 
         if (json.type === "join") {
           clientSocket.write(
-            JSON.stringify({ type: "channel_joined", user_id: 1 })
+            JSON.stringify({ type: "channel_joined", user_id: 1 }),
           );
         }
       });
@@ -127,7 +127,7 @@ describe("NVDAClient", () => {
 
     afterEach(() => {
       nvdaServerFake.close();
-      client.disconnect();
+      client.stop();
       (clientSocket as unknown) = undefined;
     });
 
@@ -140,8 +140,8 @@ describe("NVDAClient", () => {
           "remote",
           "globalPlugins",
           "remoteClient",
-          "server.pem"
-        )
+          "server.pem",
+        ),
       );
     });
 
@@ -152,14 +152,14 @@ describe("NVDAClient", () => {
           type: "join",
           connection_type: "master",
           channel: "guidepup",
-        }) + "\n"
+        }) + "\n",
       );
       expect(nvdaDataHandlerStub).toHaveBeenNthCalledWith(
         2,
         JSON.stringify({
           type: "protocol_version",
           version: 2,
-        }) + "\n"
+        }) + "\n",
       );
     });
 
@@ -186,11 +186,11 @@ describe("NVDAClient", () => {
             type: "speak",
             sequence: [null, 1, {}, "test", "  test  with   extra spaces  "],
             priority: 1,
-          }) + "\n"
+          }) + "\n",
         );
 
         expect(await speakEmittedPromise).toEqual(
-          "test, test with extra spaces"
+          "test, test with extra spaces",
         );
       });
     });
@@ -217,7 +217,7 @@ describe("NVDAClient", () => {
             vk_code: 1,
             pressed: true,
             type: "key",
-          }) + "\n"
+          }) + "\n",
         );
         expect(nvdaDataHandlerStub).toHaveBeenNthCalledWith(
           2,
@@ -227,7 +227,7 @@ describe("NVDAClient", () => {
             vk_code: 1,
             pressed: false,
             type: "key",
-          }) + "\n"
+          }) + "\n",
         );
       });
     });
@@ -257,7 +257,7 @@ describe("NVDAClient", () => {
             vk_code: 1,
             pressed: true,
             type: "key",
-          }) + "\n"
+          }) + "\n",
         );
         expect(nvdaDataHandlerStub).toHaveBeenNthCalledWith(
           2,
@@ -267,7 +267,7 @@ describe("NVDAClient", () => {
             vk_code: 3,
             pressed: true,
             type: "key",
-          }) + "\n"
+          }) + "\n",
         );
         expect(nvdaDataHandlerStub).toHaveBeenNthCalledWith(
           3,
@@ -277,7 +277,7 @@ describe("NVDAClient", () => {
             vk_code: 3,
             pressed: false,
             type: "key",
-          }) + "\n"
+          }) + "\n",
         );
         expect(nvdaDataHandlerStub).toHaveBeenNthCalledWith(
           4,
@@ -287,7 +287,7 @@ describe("NVDAClient", () => {
             vk_code: 1,
             pressed: false,
             type: "key",
-          }) + "\n"
+          }) + "\n",
         );
       });
     });
@@ -309,7 +309,7 @@ describe("NVDAClient", () => {
       it("should send a key down command for the modifier, then the key, and then a key up command in the reverse order to NVDA", () => {
         expect(nvdaDataHandlerStub).toHaveBeenNthCalledWith(
           1,
-          Modifiers.Alt.toString(true) + "\n"
+          Modifiers.Alt.toString(true) + "\n",
         );
         expect(nvdaDataHandlerStub).toHaveBeenNthCalledWith(
           2,
@@ -319,7 +319,7 @@ describe("NVDAClient", () => {
             vk_code: 1,
             pressed: true,
             type: "key",
-          }) + "\n"
+          }) + "\n",
         );
         expect(nvdaDataHandlerStub).toHaveBeenNthCalledWith(
           3,
@@ -329,11 +329,11 @@ describe("NVDAClient", () => {
             vk_code: 1,
             pressed: false,
             type: "key",
-          }) + "\n"
+          }) + "\n",
         );
         expect(nvdaDataHandlerStub).toHaveBeenNthCalledWith(
           4,
-          Modifiers.Alt.toString(false) + "\n"
+          Modifiers.Alt.toString(false) + "\n",
         );
       });
     });
@@ -358,11 +358,11 @@ describe("NVDAClient", () => {
       it("should send a key down command for the modifier, then the key, and then a key up command in the reverse order to NVDA", () => {
         expect(nvdaDataHandlerStub).toHaveBeenNthCalledWith(
           1,
-          Modifiers.Alt.toString(true) + "\n"
+          Modifiers.Alt.toString(true) + "\n",
         );
         expect(nvdaDataHandlerStub).toHaveBeenNthCalledWith(
           2,
-          Modifiers.Control.toString(true) + "\n"
+          Modifiers.Control.toString(true) + "\n",
         );
         expect(nvdaDataHandlerStub).toHaveBeenNthCalledWith(
           3,
@@ -372,7 +372,7 @@ describe("NVDAClient", () => {
             vk_code: 1,
             pressed: true,
             type: "key",
-          }) + "\n"
+          }) + "\n",
         );
         expect(nvdaDataHandlerStub).toHaveBeenNthCalledWith(
           4,
@@ -382,7 +382,7 @@ describe("NVDAClient", () => {
             vk_code: 3,
             pressed: true,
             type: "key",
-          }) + "\n"
+          }) + "\n",
         );
         expect(nvdaDataHandlerStub).toHaveBeenNthCalledWith(
           5,
@@ -392,7 +392,7 @@ describe("NVDAClient", () => {
             vk_code: 3,
             pressed: false,
             type: "key",
-          }) + "\n"
+          }) + "\n",
         );
         expect(nvdaDataHandlerStub).toHaveBeenNthCalledWith(
           6,
@@ -402,21 +402,21 @@ describe("NVDAClient", () => {
             vk_code: 1,
             pressed: false,
             type: "key",
-          }) + "\n"
+          }) + "\n",
         );
         expect(nvdaDataHandlerStub).toHaveBeenNthCalledWith(
           7,
-          Modifiers.Control.toString(false) + "\n"
+          Modifiers.Control.toString(false) + "\n",
         );
         expect(nvdaDataHandlerStub).toHaveBeenNthCalledWith(
           8,
-          Modifiers.Alt.toString(false) + "\n"
+          Modifiers.Alt.toString(false) + "\n",
         );
       });
     });
 
-    describe("when disconnect is called while sendKeyCode calls are in flight", () => {
-      let sendKeyCodePromise;
+    describe("when stop is called while sendKeyCode calls are in flight", () => {
+      let sendKeyCodePromise: Promise<void> | undefined;
 
       beforeEach(() => {
         jest.clearAllMocks();
@@ -427,7 +427,7 @@ describe("NVDAClient", () => {
         sendKeyCodePromise = undefined;
       });
 
-      it("should disconnect gracefully", async () => {
+      it("should stop gracefully", async () => {
         sendKeyCodePromise = client.sendKeyCode({
           keyCode: [
             new Key({ keyCode: 1, scanCode: 2, extended: false }),
@@ -438,7 +438,7 @@ describe("NVDAClient", () => {
           modifiers: [Modifiers.Alt, Modifiers.Control],
         });
 
-        expect(() => client.disconnect()).not.toThrow();
+        expect(() => client.stop()).not.toThrow();
       });
     });
   });
@@ -446,6 +446,133 @@ describe("NVDAClient", () => {
   describe("when no phrases have been spoken", () => {
     it("should return an empty array", async () => {
       expect(await client.spokenPhraseLog()).toEqual([]);
+    });
+  });
+
+  describe("when multiple actions are enqueued", () => {
+    it("should execute actions serially and accumulate spoken phrases", async () => {
+      const result1 = Symbol("result-1");
+      const result2 = Symbol("result-2");
+
+      const promise1 = client.enqueueAndTap(
+        async () => {
+          client.emit("speak", "first phrase");
+
+          return result1;
+        },
+        { capture: true },
+      );
+
+      const promise2 = client.enqueueAndTap(
+        async () => {
+          client.emit("speak", "second phrase");
+
+          return result2;
+        },
+        { capture: true },
+      );
+
+      const [r1, r2] = await Promise.all([promise1, promise2]);
+
+      expect(r1).toBe(result1);
+      expect(r2).toBe(result2);
+
+      expect(await client.spokenPhraseLog()).toEqual([
+        "first phrase",
+        "second phrase",
+      ]);
+    });
+
+    it("should allow accessing spoken phrase log while actions are in flight", async () => {
+      let actionStarted = false;
+      let resolveAction!: () => void;
+
+      const action = async () => {
+        actionStarted = true;
+
+        await new Promise<void>((resolve) => {
+          resolveAction = resolve;
+        });
+
+        client.emit("speak", "test phrase");
+      };
+
+      client.enqueueAndTap(action, { capture: true });
+
+      await new Promise((resolve) => {
+        const checkInterval = setInterval(() => {
+          if (actionStarted) {
+            clearInterval(checkInterval);
+            resolve(undefined);
+          }
+        }, 10);
+      });
+
+      resolveAction();
+
+      const logs = await client.spokenPhraseLog();
+
+      expect(logs).toEqual(["test phrase"]);
+    });
+  });
+
+  describe("when an enqueued action throws an error", () => {
+    it("should reject the action's promise", async () => {
+      const testError = new Error("test-action-error");
+
+      const promise = client.enqueueAndTap(
+        async () => {
+          throw testError;
+        },
+        { capture: true },
+      );
+
+      await expect(promise).rejects.toBe(testError);
+    });
+
+    it("should not log the failed action and continue processing subsequent actions", async () => {
+      const testError = new Error("test-action-error");
+      const successResult = Symbol("success-result");
+
+      const failPromise = client.enqueueAndTap(
+        async () => {
+          throw testError;
+        },
+        { capture: true },
+      );
+
+      const successPromise = client.enqueueAndTap(
+        async () => {
+          client.emit("speak", "success phrase");
+
+          return successResult;
+        },
+        { capture: true },
+      );
+
+      await expect(failPromise).rejects.toBe(testError);
+      const result = await successPromise;
+
+      expect(result).toBe(successResult);
+
+      expect(await client.spokenPhraseLog()).toEqual(["success phrase"]);
+    });
+
+    it("should not log when an action errors and capture is disabled", async () => {
+      const testError = new Error("test-action-error");
+
+      const promise = client.enqueueAndTap(
+        async () => {
+          client.emit("speak", "error phrase");
+
+          throw testError;
+        },
+        { capture: false },
+      );
+
+      await expect(promise).rejects.toBe(testError);
+
+      expect(await client.spokenPhraseLog()).toHaveLength(0);
     });
   });
 });

--- a/src/windows/NVDA/NVDAClient.ts
+++ b/src/windows/NVDA/NVDAClient.ts
@@ -1,6 +1,10 @@
 import { connect, TLSSocket } from "tls";
 import { dirname, join } from "path";
-import { ERR_NVDA_CANNOT_CONNECT, ERR_NVDA_NOT_INSTALLED } from "../errors";
+import {
+  ERR_NVDA_CANNOT_CONNECT,
+  ERR_NVDA_NOT_INSTALLED,
+  ERR_NVDA_NOT_RUNNING,
+} from "../errors";
 import { NVDA_HOST, NVDA_PORT } from "./constants";
 import { CommandOptions } from "../../CommandOptions";
 import { EventEmitter } from "events";
@@ -49,19 +53,19 @@ const CANCEL_NOT_FIRE_TIMEOUT = 1000;
 const SPEAK_DEBOUNCE_TIMEOUT = 1000;
 
 const isChannelJoinedMessage = (
-  message: NVDABaseMessage
+  message: NVDABaseMessage,
 ): message is NVDAChannelJoinedMessage => {
   return message.type === CHANNEL_JOINED;
 };
 
 const isCancelMessage = (
-  message: NVDABaseMessage
+  message: NVDABaseMessage,
 ): message is NVDACancelMessage => {
   return message.type === CANCEL;
 };
 
 const isSpeakMessage = (
-  message: NVDABaseMessage
+  message: NVDABaseMessage,
 ): message is NVDASpeakMessage => {
   return message.type === SPEAK;
 };
@@ -69,8 +73,18 @@ const isSpeakMessage = (
 const delay = async (ms: number) =>
   await new Promise((resolve) => setTimeout(resolve, ms));
 
+interface QueueAction {
+  action: () => Promise<unknown>;
+  options: Pick<CommandOptions, "capture">;
+  promise: Promise<unknown>;
+  resolve: (value: unknown) => void;
+  reject: (reason?: unknown) => void;
+}
+
 export class NVDAClient extends EventEmitter {
-  #activePromise = null;
+  #inFlight: Promise<unknown> | null = null;
+  #queue: QueueAction[] = [];
+  #stopped = false;
   #socket: TLSSocket;
   #spokenPhrases = [];
   #consecutiveConnectionFailures = 0;
@@ -82,9 +96,7 @@ export class NVDAClient extends EventEmitter {
    * @returns {Promise<string[]>} All spoken phrases
    */
   async spokenPhraseLog(): Promise<string[]> {
-    if (this.#activePromise) {
-      await this.#activePromise;
-    }
+    await this.#waitForAllActions();
 
     return this.#spokenPhrases;
   }
@@ -93,9 +105,7 @@ export class NVDAClient extends EventEmitter {
    * Clear the log of all spoken phrases for this NVDA connection.
    */
   async clearSpokenPhraseLog(): Promise<void> {
-    if (this.#activePromise) {
-      await this.#activePromise;
-    }
+    await this.#waitForAllActions();
 
     this.#spokenPhrases = [];
   }
@@ -117,7 +127,7 @@ export class NVDAClient extends EventEmitter {
       "remote",
       "globalPlugins",
       "remoteClient",
-      "server.pem"
+      "server.pem",
     );
 
     let ca;
@@ -129,7 +139,7 @@ export class NVDAClient extends EventEmitter {
     }
 
     return new Promise<void>((resolve, reject) =>
-      this.#connect(ca, options?.capture, resolve, reject)
+      this.#connect(ca, options?.capture, resolve, reject),
     );
   }
 
@@ -137,7 +147,7 @@ export class NVDAClient extends EventEmitter {
     ca: Buffer,
     capture: CommandOptions["capture"] = true,
     onSuccess?: () => void,
-    onError?: (error: Error) => void
+    onError?: (error: Error) => void,
   ): Promise<void> {
     let onSuccessCalled = false;
 
@@ -158,7 +168,7 @@ export class NVDAClient extends EventEmitter {
 
         await this.#send(connectionMessage);
         await this.#send(protocolMessage);
-      }
+      },
     );
 
     this.#socket.setEncoding("utf8");
@@ -218,7 +228,7 @@ export class NVDAClient extends EventEmitter {
         }
 
         spokenPhraseParts.push(
-          spokenPhrasePart.trim().replaceAll(/\s\s+/g, " ")
+          spokenPhrasePart.trim().replaceAll(/\s\s+/g, " "),
         );
       }
 
@@ -229,7 +239,7 @@ export class NVDAClient extends EventEmitter {
   }
 
   /**
-   * disconnect the NVDA connection.
+   * Disconnect the NVDA connection.
    */
   disconnect(): void {
     try {
@@ -240,6 +250,17 @@ export class NVDAClient extends EventEmitter {
 
     this.#socket = null;
     this.#capture = null;
+  }
+
+  /**
+   * Stop NVDA action execution.
+   */
+  async stop(): Promise<void> {
+    this.#stopped = true;
+
+    await this.#waitForAllActions();
+
+    this.disconnect();
   }
 
   /**
@@ -269,79 +290,111 @@ export class NVDAClient extends EventEmitter {
 
   /**
    * Stops the current spoken phrase, executes the provided action, and waits
-   * for the associated spoken phrase.
+   * for the associated spoken phrase. Actions are executed serially in the
+   * order they are enqueued.
    *
-   * This is used internally to ensure there isn't a race condition when
-   * calling lastSpokenPhrase() after executing an action.
-   *
-   * @param {Promise<unknown>} promise Underlying action to capture logs for.
+   * @param {() => Promise<T>} action Underlying action to capture logs for.
    * @param {object} options Additional options.
-   * @returns {Promise<unknown>}
+   * @returns {Promise<T>} Promise that resolves with the action's result.
    */
-  async waitForSpokenPhrase<T>(
+  enqueueAndTap<T>(
     action: () => Promise<T>,
-    options: Pick<CommandOptions, "capture">
+    options?: Pick<CommandOptions, "capture">,
   ): Promise<T> {
-    if (this.#activePromise) {
-      await this.#activePromise;
+    if (this.#stopped) {
+      throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
-    let activePromiseResolver: () => void;
-    this.#activePromise = new Promise<void>(
-      (resolve) => (activePromiseResolver = resolve)
-    );
+    let resolve, reject;
 
-    const spokenPhrases = [];
-    let result: T;
+    const promise = new Promise<T>((_resolve, _reject) => {
+      resolve = _resolve;
+      reject = _reject;
+    });
 
-    if (options?.capture ?? this.#capture) {
-      await this.#stopReading();
+    this.#queue.push({ action, options, promise, resolve, reject });
+    this.#processQueue();
 
-      let speakPromiseResolver: () => void;
+    return promise;
+  }
 
-      const speakPromise = new Promise<void>((resolve) => {
-        speakPromiseResolver = resolve;
-      });
+  async #waitForAllActions(): Promise<void> {
+    const allPromises = this.#queue.map(({ promise }) => promise);
 
-      let timeoutId: NodeJS.Timeout = null;
+    if (this.#inFlight) {
+      allPromises.push(this.#inFlight);
+    }
 
-      const speakHandler = (spokenPhrase) => {
-        spokenPhrases.push(spokenPhrase);
+    await Promise.allSettled(allPromises);
+  }
 
-        if ((options?.capture ?? this.#capture) === "initial") {
-          clearTimeout(timeoutId);
+  async #processQueue() {
+    if (this.#inFlight || this.#queue.length === 0) {
+      return;
+    }
+
+    const { action, options, resolve, reject, promise } = this.#queue.shift()!;
+    this.#inFlight = promise;
+
+    try {
+      if (this.#stopped) {
+        throw new Error(ERR_NVDA_NOT_RUNNING);
+      }
+
+      const spokenPhrases: string[] = [];
+      let result: unknown;
+
+      if (options?.capture ?? this.#capture) {
+        await this.#stopReading();
+
+        let speakPromiseResolver: () => void;
+
+        const speakPromise = new Promise<void>((resolve) => {
+          speakPromiseResolver = resolve;
+        });
+
+        let timeoutId: NodeJS.Timeout = null;
+
+        const speakHandler = (spokenPhrase: string) => {
+          spokenPhrases.push(spokenPhrase);
+
+          if ((options?.capture ?? this.#capture) === "initial") {
+            clearTimeout(timeoutId);
+            this.removeListener(SPEAK, speakHandler);
+            speakPromiseResolver();
+          } else if (timeoutId !== null) {
+            clearTimeout(timeoutId);
+            timeoutId = setTimeout(timeoutHandler, SPEAK_DEBOUNCE_TIMEOUT);
+          }
+        };
+
+        const timeoutHandler = () => {
           this.removeListener(SPEAK, speakHandler);
           speakPromiseResolver();
-        } else if (timeoutId !== null) {
-          clearTimeout(timeoutId);
-          timeoutId = setTimeout(timeoutHandler, SPEAK_DEBOUNCE_TIMEOUT);
-        }
-      };
+        };
 
-      const timeoutHandler = () => {
-        this.removeListener(SPEAK, speakHandler);
-        speakPromiseResolver();
-      };
+        this.addListener(SPEAK, speakHandler);
 
-      this.addListener(SPEAK, speakHandler);
+        result = await action();
 
-      result = await action();
+        timeoutId = setTimeout(timeoutHandler, SPEAK_DEBOUNCE_TIMEOUT);
 
-      timeoutId = setTimeout(timeoutHandler, SPEAK_DEBOUNCE_TIMEOUT);
+        await speakPromise;
 
-      await speakPromise;
+        timeoutId = null;
+      } else {
+        result = await action();
+      }
 
-      timeoutId = null;
-    } else {
-      result = await action();
+      this.#spokenPhrases.push(spokenPhrases.join(". "));
+
+      resolve(result);
+    } catch (error) {
+      reject(error);
+    } finally {
+      this.#inFlight = null;
+      this.#processQueue();
     }
-
-    this.#spokenPhrases.push(spokenPhrases.join(". "));
-
-    activePromiseResolver();
-    this.#activePromise = null;
-
-    return result;
   }
 
   async #stopReading(): Promise<void> {


### PR DESCRIPTION
# Issue

Relates to #113

## Details

Improves the previous update to the VO stop behaviour by:

1. Ensuring that wait on the in-flight actions as well as any queued actions
2. Implement the same safeguards in NVDA client to ensure wait for in-flight/queued actions to finish before stopping (and ensuring no new actions can be issued while stop is in progress)

## CheckList

- [ ] Has been tested (where required).
