### PR TITLE
feat!: set the default `capture` option to `"initial"`

### DIFF
--- a/examples/playwright-nvda/tests/chromium/chromium.spokenPhrase.textarea.snapshot.json
+++ b/examples/playwright-nvda/tests/chromium/chromium.spokenPhrase.textarea.snapshot.json
@@ -1,1 +1,1 @@
-["A", "b", "c", "Abc selected", "blank. unselected", "1", "2", "3"]
+["A", "b", "c", "Abc selected", "blank", "1", "2", "3"]

--- a/src/CommandOptions.ts
+++ b/src/CommandOptions.ts
@@ -7,7 +7,7 @@ export interface CommandOptions {
    * subsequent content.
    * - `false` will disable capture.
    *
-   * Default is `true`.
+   * Default is `"initial"`.
    */
   capture?: true | false | "initial";
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export const DEFAULT_TIMEOUT = 10000;
 export const DEFAULT_MAX_BUFFER = 1000 * 1000 * 100;
 export const DEFAULT_CLICK_BUTTON = "left";
 export const DEFAULT_CLICK_COUNT = 1;
+export const DEFAULT_CAPTURE = "initial";
 
 export const ERR_WAITING_TIMEOUT = "Timed out waiting.";
 export const ERR_APPLE_SCRIPT_TIMED_OUT = "AppleEvent timed out";

--- a/src/macOS/VoiceOver/VoiceOver.ts
+++ b/src/macOS/VoiceOver/VoiceOver.ts
@@ -210,6 +210,11 @@ export class VoiceOver implements ScreenReader {
    * })();
    * ```
    *
+   * Note: By default the `capture` option is set to `"initial"` to capture the
+   * first "page" of output, but not any subsequent content. To enable full
+   * capture set `{ capture: true }`, or to disable capture set
+   * `{ capture: false }`.
+   *
    * @param {object} [options] Additional options.
    */
   async start(options?: CommandOptions): Promise<void> {

--- a/src/macOS/VoiceOver/VoiceOverClient.test.ts
+++ b/src/macOS/VoiceOver/VoiceOverClient.test.ts
@@ -231,7 +231,7 @@ describe("VoiceOverClient", () => {
       });
     });
 
-    describe("when enqueueAndTap is called with capture enabled (by default or via options) but is unsuccessful in retrieving the last spoken phrase", () => {
+    describe("when enqueueAndTap is called with capture enabled but is unsuccessful in retrieving the last spoken phrase", () => {
       const expectedResult = Symbol("test-expected-result");
       let resultPromise: Promise<unknown>,
         resolver: (r: typeof expectedResult) => void;
@@ -247,7 +247,9 @@ describe("VoiceOverClient", () => {
             resolver = resolve;
           });
 
-        resultPromise = voiceOverClient.enqueueAndTap(action);
+        resultPromise = voiceOverClient.enqueueAndTap(action, {
+          capture: true,
+        });
       });
 
       afterEach(async () => {
@@ -282,7 +284,7 @@ describe("VoiceOverClient", () => {
       });
     });
 
-    describe("when enqueueAndTap is called with capture enabled (by default or via options) but the phrases emitted by VO never stabilize (e.g. live region that announces updates every second)", () => {
+    describe("when enqueueAndTap is called with capture enabled but the phrases emitted by VO never stabilize (e.g. live region that announces updates every second)", () => {
       const expectedResult = Symbol("test-expected-result");
       let resultPromise: Promise<unknown>,
         resolver: (r: typeof expectedResult) => void;
@@ -298,7 +300,9 @@ describe("VoiceOverClient", () => {
             resolver = resolve;
           });
 
-        resultPromise = voiceOverClient.enqueueAndTap(action);
+        resultPromise = voiceOverClient.enqueueAndTap(action, {
+          capture: true,
+        });
       });
 
       afterEach(async () => {

--- a/src/macOS/VoiceOver/VoiceOverClient.ts
+++ b/src/macOS/VoiceOver/VoiceOverClient.ts
@@ -8,6 +8,7 @@ import {
 } from "./constants";
 import { cleanSpokenPhrase } from "./cleanSpokenPhrase";
 import { CommandOptions } from "../../CommandOptions";
+import { DEFAULT_CAPTURE } from "../../constants";
 import { ERR_VOICE_OVER_NOT_RUNNING } from "../errors";
 import { itemText as getItemText } from "./itemText";
 import { lastSpokenPhrase } from "./lastSpokenPhrase";
@@ -38,7 +39,7 @@ export class VoiceOverClient {
   #clearedLastSpokenPhrase: string | null = null;
 
   constructor(options?: Pick<CommandOptions, "capture">) {
-    this.#capture = options?.capture ?? true;
+    this.#capture = options?.capture ?? DEFAULT_CAPTURE;
   }
 
   /**

--- a/src/windows/NVDA/NVDA.ts
+++ b/src/windows/NVDA/NVDA.ts
@@ -126,6 +126,11 @@ export class NVDA implements ScreenReader {
    *   await nvda.stop();
    * })();
    * ```
+   *
+   * Note: By default the `capture` option is set to `"initial"` to capture the
+   * first "page" of output, but not any subsequent content. To enable full
+   * capture set `{ capture: true }`, or to disable capture set
+   * `{ capture: false }`.
    */
   async start(options?: CaptureCommandOptions): Promise<void> {
     if (!(await this.detect())) {

--- a/src/windows/NVDA/NVDAClient.ts
+++ b/src/windows/NVDA/NVDAClient.ts
@@ -7,6 +7,7 @@ import {
 } from "../errors";
 import { NVDA_HOST, NVDA_PORT } from "./constants";
 import { CommandOptions } from "../../CommandOptions";
+import { DEFAULT_CAPTURE } from "../../constants";
 import { EventEmitter } from "events";
 import { getNVDAInstallationPath } from "./getNVDAInstallationPath";
 import { KeyCodeCommand } from "../KeyCodeCommand";
@@ -147,7 +148,7 @@ export class NVDAClient extends EventEmitter {
 
   async #connect(
     ca: Buffer,
-    capture: CommandOptions["capture"] = true,
+    capture: CommandOptions["capture"] = DEFAULT_CAPTURE,
     onSuccess?: () => void,
     onError?: (error: Error) => void,
   ): Promise<void> {


### PR DESCRIPTION
# Issue

No issue.

## Details

**BREAKING CHANGE**: Sets the default `capture` to `"initial"` for both NVDA and VoiceOver.

This is based on feedback that performance is key, especially for VoiceOver tests, and the observation that most consumers aren't asserting on secondary announcements such as VoiceOver hints.

Consumers can revert to the old default by setting `{ capture: true }` in the `*.start()` command options, or indeed, on a per command basis for any command, i.e.

```ts
await voiceOver.start(); // Capture initial logs for each command by default
await voiceOver.next(); // Capture the initial logs for this command
await voiceOver.next({ capture: false }); // Don't capture logs for this command
await voiceOver.next({ capture: true }); // Capture all logs for this command
await voiceOver.stop();

await voiceOver.start({ capture: true }); // Capture all logs for each command
await voiceOver.next({ capture: "initial" }); // Capture the initial logs for this command
await voiceOver.next({ capture: false }); // Don't capture logs for this command
await voiceOver.next(); // Capture all logs for this command
await voiceOver.stop();

await voiceOver.start({ capture: false }); // Don't capture logs for each command
await voiceOver.next({ capture: "initial" }); // Capture the initial logs for this command
await voiceOver.next(); // Don't capture logs for this command
await voiceOver.next({ capture: true }); // Capture all logs for this command
await voiceOver.stop();
```

## CheckList

- [ ] Has been tested (where required).
