### PR TITLE
feat: screen reader settings getters and setters

### DIFF
--- a/.github/workflows/playwright-nvda.yml
+++ b/.github/workflows/playwright-nvda.yml
@@ -22,12 +22,12 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-      - run: npx -y --min-release-age=0 @guidepup/setup@0.24.1 setup --ci --macos-record
+      - run: npx -y @guidepup/setup@0.24.1 setup --ci
       - run: npm ci --no-audit --no-fund --no-progress
       - run: npm run build
       - run: npm ci --prefix ./examples/playwright-nvda --no-audit --no-fund --no-progress
       - run: npm --prefix ./examples/playwright-nvda rebuild ffmpeg-static --ignore-scripts=false
-      - run: npx -y --min-release-age=0 @guidepup/setup@0.24.1 install
+      - run: npx -y @guidepup/setup@0.24.1 install
       - run: npm --prefix ./examples/playwright-nvda run browsers
       - run: npm --prefix ./examples/playwright-nvda run test:${{ matrix.browser }}
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright-screenreader.yml
+++ b/.github/workflows/playwright-screenreader.yml
@@ -22,13 +22,13 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-      - run: npx -y --min-release-age=0 @guidepup/setup@0.24.1 setup --ci --macos-record
+      - run: npx -y @guidepup/setup@0.24.1 setup --ci --macos-record
       - run: npm ci --no-audit --no-fund --no-progress
       - run: npm run build
       - run: npm ci --prefix ./examples/playwright-screenreader --no-audit --no-fund --no-progress
       - run: npm --prefix ./examples/playwright-screenreader rebuild ffmpeg-static --ignore-scripts=false
       - run: npm --prefix ./examples/playwright-screenreader run browsers
-      - run: npx -y --min-release-age=0 @guidepup/setup@0.24.1 install
+      - run: npx -y @guidepup/setup@0.24.1 install
       - run: npm --prefix ./examples/playwright-screenreader run test:${{ matrix.browser }}
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/playwright-voiceover.yml
+++ b/.github/workflows/playwright-voiceover.yml
@@ -22,13 +22,13 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-      - run: npx -y --min-release-age=0 @guidepup/setup@0.24.1 setup --ci --macos-record
+      - run: npx -y @guidepup/setup@0.24.1 setup --ci --macos-record
       - run: npm ci --no-audit --no-fund --no-progress
       - run: npm run build
       - run: npm ci --prefix ./examples/playwright-voiceover --no-audit --no-fund --no-progress
       - run: npm --prefix ./examples/playwright-voiceover rebuild ffmpeg-static --ignore-scripts=false
       - run: npm --prefix ./examples/playwright-voiceover run browsers
-      - run: npx -y --min-release-age=0 @guidepup/setup@0.24.1 install
+      - run: npx -y @guidepup/setup@0.24.1 install
       - run: npm --prefix ./examples/playwright-voiceover run test:${{ matrix.browser }}
       - uses: actions/upload-artifact@v4
         if: always()

--- a/examples/playwright-nvda/nvda-test.ts
+++ b/examples/playwright-nvda/nvda-test.ts
@@ -134,7 +134,21 @@ const nvdaTest = test.extend<{ nvda: NVDAPlaywright }>({
         await nvdaPlaywright.clearSpokenPhraseLog();
       };
 
-      await nvdaPlaywright.start({ capture: "initial" });
+      await nvdaPlaywright.start({
+        capture: "initial",
+        settings: {
+          speech: {
+            oneCore: {
+              voice:
+                "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Speech_OneCore\\Voices\\Tokens\\MSTTS_V110_enGB_SusanM",
+            },
+          },
+          speechViewer: {
+            autoPositionWindow: false,
+            x: 500,
+          },
+        },
+      });
 
       await use(nvdaPlaywright);
     } finally {

--- a/examples/playwright-nvda/nvda-test.ts
+++ b/examples/playwright-nvda/nvda-test.ts
@@ -143,10 +143,13 @@ const nvdaTest = test.extend<{ nvda: NVDAPlaywright }>({
                 "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Speech_OneCore\\Voices\\Tokens\\MSTTS_V110_enGB_SusanM",
             },
           },
-          speechViewer: {
-            x: 500,
-            height: 200,
-            width: 1000,
+          vision: {
+            NVDAHighlighter: {
+              highlightFocus: false,
+              highlightNavigator: false,
+              highlightBrowseMode: false,
+              enabled: false,
+            },
           },
         },
       });

--- a/examples/playwright-nvda/nvda-test.ts
+++ b/examples/playwright-nvda/nvda-test.ts
@@ -144,8 +144,9 @@ const nvdaTest = test.extend<{ nvda: NVDAPlaywright }>({
             },
           },
           speechViewer: {
-            autoPositionWindow: false,
             x: 500,
+            height: 200,
+            width: 1000,
           },
         },
       });

--- a/examples/playwright-voiceover/voiceover-test.ts
+++ b/examples/playwright-voiceover/voiceover-test.ts
@@ -75,7 +75,13 @@ const voTest = test.extend<{ voiceOver: VoiceOverPlaywright }>({
         }
       };
 
-      await voiceOverPlaywright.start({ capture: "initial" });
+      await voiceOverPlaywright.start({
+        capture: "initial",
+        settings: {
+          SCRCategories_SCRCategorySystemWide_SCRSpeechLanguages_default_SCRSpeechComponentSettings_SCRVoiceIdentifier:
+            "com.apple.speech.synthesis.voice.custom.siri.martha.compact",
+        },
+      });
 
       await use(voiceOverPlaywright);
     } finally {

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,8 +23,6 @@ module.exports = {
     "<rootDir>/src/macOS/KeyCodes.ts",
     "<rootDir>/src/macOS/KeystrokeCommand.ts",
     "<rootDir>/src/macOS/Modifiers.ts",
-    // TODO: coverage needed for VoiceOver preferences
-    "<rootDir>/src/macOS/VoiceOver/preferences",
     "<rootDir>/src/macOS/VoiceOver/ClickButton.ts",
     "<rootDir>/src/macOS/VoiceOver/ClickCount.ts",
     "<rootDir>/src/macOS/VoiceOver/CommanderCommands.ts",

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,7 @@ module.exports = {
     "<rootDir>/src/IScreenReader.ts",
     // TODO: coverage needed for ScreenReader
     "<rootDir>/src/ScreenReader.ts",
+    "<rootDir>/src/StartOptions.ts",
     "<rootDir>/src/macOS/Applications.ts",
     "<rootDir>/src/macOS/KeyboardCommand.ts",
     "<rootDir>/src/macOS/KeyCodeCommand.ts",

--- a/jest.config.js
+++ b/jest.config.js
@@ -32,6 +32,7 @@ module.exports = {
     "<rootDir>/src/macOS/VoiceOver/Places.ts",
     "<rootDir>/src/windows/NVDA/keyCodeCommands.ts",
     // TODO: coverage needed for NVDA
+    "<rootDir>/src/windows/NVDA/config",
     "<rootDir>/src/windows/NVDA/NVDA.ts",
     "<rootDir>/src/windows/NVDA/NVDAClient.ts",
   ],

--- a/jest.config.js
+++ b/jest.config.js
@@ -32,7 +32,6 @@ module.exports = {
     "<rootDir>/src/macOS/VoiceOver/Places.ts",
     "<rootDir>/src/windows/NVDA/keyCodeCommands.ts",
     // TODO: coverage needed for NVDA
-    "<rootDir>/src/windows/NVDA/config",
     "<rootDir>/src/windows/NVDA/NVDA.ts",
     "<rootDir>/src/windows/NVDA/NVDAClient.ts",
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@guidepup/guidepup",
       "version": "0.29.2",
       "license": "MIT",
+      "dependencies": {
+        "plist": "^5.0.0"
+      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/jest": "^30.0.0",
@@ -2142,6 +2145,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
     },
     "node_modules/acorn": {
       "version": "8.17.0",
@@ -4900,6 +4912,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/plist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-5.0.0.tgz",
+      "integrity": "sha512-20N+g1DvMm/DFRbsvER7tT4wDryq0WunK7VMkDaiJcKNapAnUMkTsAnacFYf8n420F4Hf6/hefgmJRkMb1M0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5997,6 +6022,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.29.2",
       "license": "MIT",
       "dependencies": {
-        "plist": "^5.0.0"
+        "plist": "^4.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -4913,9 +4913,9 @@
       }
     },
     "node_modules/plist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-5.0.0.tgz",
-      "integrity": "sha512-20N+g1DvMm/DFRbsvER7tT4wDryq0WunK7VMkDaiJcKNapAnUMkTsAnacFYf8n420F4Hf6/hefgmJRkMb1M0fg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-4.0.0.tgz",
+      "integrity": "sha512-4dOqNo0Y2NpfSf9q4+zr4bh7pzNWeckIam34Z0KYJhg8qtNNfh59VbD+Yna5SjwcxawVvLKx5w5FtuCijpEF4Q==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.10",

--- a/package.json
+++ b/package.json
@@ -48,5 +48,7 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.61.1"
   },
-  "dependencies": {}
+  "dependencies": {
+    "plist": "^5.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "typescript-eslint": "^8.61.1"
   },
   "dependencies": {
-    "plist": "^5.0.0"
+    "plist": "^4.0.0"
   }
 }

--- a/src/IScreenReader.ts
+++ b/src/IScreenReader.ts
@@ -167,4 +167,27 @@ export interface IScreenReader {
    * Clear the log of all visited item text for this screen reader instance.
    */
   clearItemTextLog(): Promise<void>;
+
+  /**
+   * Returns all available settings for the screen reader.
+   *
+   * @returns All available settings values.
+   */
+  getSettings(): Record<string, unknown>;
+
+  /**
+   * Returns the value of a screen reader setting.
+   *
+   * @param key The setting name.
+   * @returns The setting value.
+   */
+  getSetting(key: string): unknown;
+
+  /**
+   * Sets the value of a screen reader setting.
+   *
+   * @param key The setting name.
+   * @param value The value to assign.
+   */
+  setSetting(key: string, value: unknown): void;
 }

--- a/src/IScreenReader.ts
+++ b/src/IScreenReader.ts
@@ -1,6 +1,7 @@
 import { ClickOptions } from "./ClickOptions";
 import type { CommandOptions } from "./CommandOptions";
 import type { KeyboardOptions } from "./KeyboardOptions";
+import type { StartOptions } from "./StartOptions";
 
 export interface IScreenReader {
   /**
@@ -27,7 +28,7 @@ export interface IScreenReader {
    *
    * @param {object} [options] Additional options.
    */
-  start(options?: CommandOptions): Promise<void>;
+  start(options?: StartOptions): Promise<void>;
 
   /**
    * Turn the screen reader off.

--- a/src/IScreenReader.ts
+++ b/src/IScreenReader.ts
@@ -169,22 +169,22 @@ export interface IScreenReader {
   clearItemTextLog(): Promise<void>;
 
   /**
-   * Returns all available settings for the screen reader.
+   * Returns all the current settings for this screen reader instance.
    *
-   * @returns All available settings values.
+   * @returns {Record<string, unknown>} Current settings values.
    */
   getSettings(): Record<string, unknown>;
 
   /**
-   * Returns the value of a screen reader setting.
+   * Returns the value of a setting for this screen reader instance.
    *
    * @param key The setting name.
-   * @returns The setting value.
+   * @returns {unknown} The setting value.
    */
   getSetting(key: string): unknown;
 
   /**
-   * Sets the value of a screen reader setting.
+   * Sets the value of a setting for this screen reader instance.
    *
    * @param key The setting name.
    * @param value The value to assign.

--- a/src/IScreenReader.ts
+++ b/src/IScreenReader.ts
@@ -182,14 +182,4 @@ export interface IScreenReader {
    * @returns {unknown} The setting value.
    */
   getSetting(key: string): unknown;
-
-  /**
-   * Sets the value of a setting for this screen reader instance.
-   *
-   * Note: Some settings must be set before or during at startup to take effect.
-   *
-   * @param key The setting name.
-   * @param value The value to assign.
-   */
-  setSetting(key: string, value: unknown): void;
 }

--- a/src/IScreenReader.ts
+++ b/src/IScreenReader.ts
@@ -186,6 +186,8 @@ export interface IScreenReader {
   /**
    * Sets the value of a setting for this screen reader instance.
    *
+   * Note: Some settings must be set before or during at startup to take effect.
+   *
    * @param key The setting name.
    * @param value The value to assign.
    */

--- a/src/ScreenReader.ts
+++ b/src/ScreenReader.ts
@@ -4,6 +4,7 @@ import { ERR_NO_AVAILABLE_SUPPORTED_SCREEN_READERS } from "./errors";
 import type { IScreenReader } from "./IScreenReader";
 import { KeyboardOptions } from "./KeyboardOptions";
 import { nvda } from "./windows";
+import type { StartOptions } from "./StartOptions";
 import { voiceOver } from "./macOS";
 
 export class ScreenReader implements IScreenReader {
@@ -55,7 +56,7 @@ export class ScreenReader implements IScreenReader {
    *
    * @param {object} [options] Additional options.
    */
-  start(options?: CommandOptions): Promise<void> {
+  start(options?: StartOptions): Promise<void> {
     return this.implementation.start(options);
   }
 
@@ -251,6 +252,8 @@ export class ScreenReader implements IScreenReader {
 
   /**
    * Sets the value of a setting for this screen reader instance.
+   *
+   * Note: Some settings must be set before or during at startup to take effect.
    *
    * @param key The setting name.
    * @param value The value to assign.

--- a/src/ScreenReader.ts
+++ b/src/ScreenReader.ts
@@ -229,4 +229,33 @@ export class ScreenReader implements IScreenReader {
   clearItemTextLog(): Promise<void> {
     return this.implementation.clearItemTextLog();
   }
+
+  /**
+   * Returns all available settings for the screen reader.
+   *
+   * @returns All available settings values.
+   */
+  getSettings(): Record<string, unknown> {
+    return this.implementation.getSettings();
+  }
+
+  /**
+   * Returns the value of a screen reader setting.
+   *
+   * @param key The setting name.
+   * @returns The setting value.
+   */
+  getSetting(key: string): unknown {
+    return this.implementation.getSetting(key);
+  }
+
+  /**
+   * Sets the value of a screen reader setting.
+   *
+   * @param key The setting name.
+   * @param value The value to assign.
+   */
+  setSetting(key: string, value: unknown): void {
+    return this.implementation.setSetting(key, value);
+  }
 }

--- a/src/ScreenReader.ts
+++ b/src/ScreenReader.ts
@@ -249,16 +249,4 @@ export class ScreenReader implements IScreenReader {
   getSetting(key: string): unknown {
     return this.implementation.getSetting(key);
   }
-
-  /**
-   * Sets the value of a setting for this screen reader instance.
-   *
-   * Note: Some settings must be set before or during at startup to take effect.
-   *
-   * @param key The setting name.
-   * @param value The value to assign.
-   */
-  setSetting(key: string, value: unknown): void {
-    return this.implementation.setSetting(key, value);
-  }
 }

--- a/src/ScreenReader.ts
+++ b/src/ScreenReader.ts
@@ -231,26 +231,26 @@ export class ScreenReader implements IScreenReader {
   }
 
   /**
-   * Returns all available settings for the screen reader.
+   * Returns all the current settings for this screen reader instance.
    *
-   * @returns All available settings values.
+   * @returns {Record<string, unknown>} Current settings values.
    */
   getSettings(): Record<string, unknown> {
     return this.implementation.getSettings();
   }
 
   /**
-   * Returns the value of a screen reader setting.
+   * Returns the value of a setting for this screen reader instance.
    *
    * @param key The setting name.
-   * @returns The setting value.
+   * @returns {unknown} The setting value.
    */
   getSetting(key: string): unknown {
     return this.implementation.getSetting(key);
   }
 
   /**
-   * Sets the value of a screen reader setting.
+   * Sets the value of a setting for this screen reader instance.
    *
    * @param key The setting name.
    * @param value The value to assign.

--- a/src/StartOptions.ts
+++ b/src/StartOptions.ts
@@ -1,0 +1,8 @@
+import { CommandOptions } from "./CommandOptions";
+
+export interface StartOptions extends CommandOptions {
+  /**
+   * Screen reader settings to apply on startup.
+   */
+  settings?: Record<string, unknown>;
+}

--- a/src/deepMerge.test.ts
+++ b/src/deepMerge.test.ts
@@ -1,0 +1,60 @@
+import { deepMerge } from "./deepMerge";
+
+describe("deepMerge", () => {
+  it.each`
+    description                           | target                   | source             | expected
+    ${"empty objects"}                    | ${{}}                    | ${{}}              | ${{}}
+    ${"adds new keys"}                    | ${{ a: 1 }}              | ${{ b: 2 }}        | ${{ a: 1, b: 2 }}
+    ${"overwrites primitive values"}      | ${{ a: 1 }}              | ${{ a: 2 }}        | ${{ a: 2 }}
+    ${"merges nested objects"}            | ${{ a: { b: 1, c: 2 } }} | ${{ a: { b: 3 } }} | ${{ a: { b: 3, c: 2 } }}
+    ${"overwrites object with primitive"} | ${{ a: { b: 1 } }}       | ${{ a: "value" }}  | ${{ a: "value" }}
+    ${"overwrites primitive with object"} | ${{ a: "value" }}        | ${{ a: { b: 1 } }} | ${{ a: { b: 1 } }}
+    ${"replaces arrays"}                  | ${{ a: [1, 2] }}         | ${{ a: [3] }}      | ${{ a: [3] }}
+    ${"handles null values"}              | ${{ a: { b: 1 } }}       | ${{ a: null }}     | ${{ a: null }}
+  `("$description", ({ target, source, expected }) => {
+    expect(deepMerge(target, source)).toEqual(expected);
+  });
+
+  it("should not mutate the target", () => {
+    const target = {
+      a: {
+        b: 1,
+      },
+    };
+
+    deepMerge(target, {
+      a: {
+        c: 2,
+      },
+    });
+
+    expect(target).toEqual({
+      a: {
+        b: 1,
+      },
+    });
+  });
+
+  it("should not mutate the source", () => {
+    const source = {
+      a: {
+        c: 2,
+      },
+    };
+
+    deepMerge(
+      {
+        a: {
+          b: 1,
+        },
+      },
+      source,
+    );
+
+    expect(source).toEqual({
+      a: {
+        c: 2,
+      },
+    });
+  });
+});

--- a/src/deepMerge.ts
+++ b/src/deepMerge.ts
@@ -1,0 +1,22 @@
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function deepMerge(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...target };
+
+  for (const [key, sourceValue] of Object.entries(source)) {
+    const targetValue = result[key];
+
+    if (isPlainObject(targetValue) && isPlainObject(sourceValue)) {
+      result[key] = deepMerge(targetValue, sourceValue);
+    } else {
+      result[key] = sourceValue;
+    }
+  }
+
+  return result;
+}

--- a/src/macOS/VoiceOver/VoiceOver.test.ts
+++ b/src/macOS/VoiceOver/VoiceOver.test.ts
@@ -8,7 +8,7 @@ import {
   getPreference,
   getPreferences,
   mountGuidepupPreferences,
-  setPreference,
+  setPreferences,
   unmountGuidepupPreferences,
 } from "./preferences";
 import { CommanderCommands } from "./CommanderCommands";
@@ -40,7 +40,7 @@ jest.mock("./preferences", () => ({
   getPreference: jest.fn(),
   getPreferences: jest.fn(),
   mountGuidepupPreferences: jest.fn(),
-  setPreference: jest.fn(),
+  setPreferences: jest.fn(),
   unmountGuidepupPreferences: jest.fn(),
 }));
 jest.mock("./VoiceOverClient", () => ({
@@ -328,6 +328,18 @@ describe("VoiceOver", () => {
         });
       });
 
+      describe("when called with custom settings", () => {
+        const settings = { testSettingKey: "test-setting-value" };
+
+        beforeEach(async () => {
+          await vo.start({ settings });
+        });
+
+        it("should configure VoiceOver with the desired settings", () => {
+          expect(setPreferences).toHaveBeenCalledWith(settings);
+        });
+      });
+
       describe("when VoiceOver does not become ready", () => {
         const startupError = new Error("VoiceOver did not become ready");
         let thrownError: Error;
@@ -405,43 +417,6 @@ describe("VoiceOver", () => {
         await vo.stop();
 
         expect(result).toBe(settingStub);
-      });
-    });
-  });
-
-  describe("setSetting", () => {
-    describe("when VoiceOver is not running", () => {
-      const settingKeyStub = "test-setting";
-      const settingValueStub = "test-value";
-
-      it("should queue the setting until VoiceOver starts", async () => {
-        vo.setSetting(settingKeyStub, settingValueStub);
-
-        expect(setPreference).not.toHaveBeenCalled();
-
-        await vo.start();
-
-        expect(setPreference).toHaveBeenCalledWith(
-          settingKeyStub,
-          settingValueStub,
-        );
-
-        await vo.stop();
-      });
-    });
-
-    describe("when VoiceOver is running", () => {
-      it("should set the preference immediately", async () => {
-        await vo.start();
-
-        vo.setSetting("test-setting", "test-value");
-
-        expect(setPreference).toHaveBeenCalledWith(
-          "test-setting",
-          "test-value",
-        );
-
-        await vo.stop();
       });
     });
   });

--- a/src/macOS/VoiceOver/VoiceOver.test.ts
+++ b/src/macOS/VoiceOver/VoiceOver.test.ts
@@ -5,7 +5,10 @@ import {
   ERR_VOICE_OVER_NOT_SUPPORTED,
 } from "../errors";
 import {
+  getPreference,
+  getPreferences,
   mountGuidepupPreferences,
+  setPreference,
   unmountGuidepupPreferences,
 } from "./preferences";
 import { CommanderCommands } from "./CommanderCommands";
@@ -24,10 +27,6 @@ import { VoiceOverMouse } from "./VoiceOverMouse";
 import { waitForNotRunning } from "./waitForNotRunning";
 import { waitForRunning } from "./waitForRunning";
 
-jest.mock("./preferences", () => ({
-  mountGuidepupPreferences: jest.fn(),
-  unmountGuidepupPreferences: jest.fn(),
-}));
 jest.mock("../activate", () => ({
   activate: jest.fn(),
 }));
@@ -36,6 +35,13 @@ jest.mock("../../isKeyboard", () => ({
 }));
 jest.mock("../isMacOS", () => ({
   isMacOS: jest.fn(),
+}));
+jest.mock("./preferences", () => ({
+  getPreference: jest.fn(),
+  getPreferences: jest.fn(),
+  mountGuidepupPreferences: jest.fn(),
+  setPreference: jest.fn(),
+  unmountGuidepupPreferences: jest.fn(),
 }));
 jest.mock("./VoiceOverClient", () => ({
   VoiceOverClient: jest.fn(),
@@ -136,6 +142,8 @@ describe("VoiceOver", () => {
     );
 
     jest.mocked(isMacOS).mockReturnValue(true);
+    jest.mocked(getPreferences).mockReturnValue({});
+    jest.mocked(getPreference).mockReturnValue(undefined);
 
     vo = new VoiceOver();
     result = undefined;
@@ -320,7 +328,7 @@ describe("VoiceOver", () => {
         });
       });
 
-      describe('when VoiceOver does not become ready', () => {
+      describe("when VoiceOver does not become ready", () => {
         const startupError = new Error("VoiceOver did not become ready");
         let thrownError: Error;
 
@@ -334,13 +342,13 @@ describe("VoiceOver", () => {
           }
         });
 
-        test('should retry from a clean VoiceOver process', () => {
+        test("should retry from a clean VoiceOver process", () => {
           expect(start).toHaveBeenCalledTimes(2);
           expect(terminateVoiceOverProcess).toHaveBeenCalledTimes(3);
           expect(waitForNotRunning).toHaveBeenCalledTimes(2);
         });
 
-        test('should return a stable startup error with the readiness failure as its cause', () => {
+        test("should return a stable startup error with the readiness failure as its cause", () => {
           expect(thrownError).toEqual(
             new Error(ERR_VOICE_OVER_CANNOT_BE_STARTED, {
               cause: startupError,
@@ -348,9 +356,92 @@ describe("VoiceOver", () => {
           );
         });
 
-        test('should unmount Guidepup preferences after failing', () => {
+        test("should unmount Guidepup preferences after failing", () => {
           expect(unmountGuidepupPreferences).toHaveBeenCalledTimes(1);
         });
+      });
+    });
+  });
+
+  describe("getSettings", () => {
+    describe("when VoiceOver is not running", () => {
+      it("should throw an error", () => {
+        expect(() => vo.getSettings()).toThrow(ERR_VOICE_OVER_NOT_RUNNING);
+      });
+    });
+
+    describe("when VoiceOver is running", () => {
+      const settingsStub = { testSetting: true };
+
+      it("should return the current settings", async () => {
+        jest.mocked(getPreferences).mockReturnValue(settingsStub);
+
+        await vo.start();
+        result = vo.getSettings();
+        await vo.stop();
+
+        expect(result).toEqual(settingsStub);
+      });
+    });
+  });
+
+  describe("getSetting", () => {
+    describe("when VoiceOver is not running", () => {
+      it("should throw an error", () => {
+        expect(() => vo.getSetting("test-setting")).toThrow(
+          ERR_VOICE_OVER_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe("when VoiceOver is running", () => {
+      const settingStub = "test-value";
+
+      it("should return the value for the setting", async () => {
+        jest.mocked(getPreference).mockReturnValue(settingStub);
+
+        await vo.start();
+        result = vo.getSetting("test-setting");
+        await vo.stop();
+
+        expect(result).toBe(settingStub);
+      });
+    });
+  });
+
+  describe("setSetting", () => {
+    describe("when VoiceOver is not running", () => {
+      const settingKeyStub = "test-setting";
+      const settingValueStub = "test-value";
+
+      it("should queue the setting until VoiceOver starts", async () => {
+        vo.setSetting(settingKeyStub, settingValueStub);
+
+        expect(setPreference).not.toHaveBeenCalled();
+
+        await vo.start();
+
+        expect(setPreference).toHaveBeenCalledWith(
+          settingKeyStub,
+          settingValueStub,
+        );
+
+        await vo.stop();
+      });
+    });
+
+    describe("when VoiceOver is running", () => {
+      it("should set the preference immediately", async () => {
+        await vo.start();
+
+        vo.setSetting("test-setting", "test-value");
+
+        expect(setPreference).toHaveBeenCalledWith(
+          "test-setting",
+          "test-value",
+        );
+
+        await vo.stop();
       });
     });
   });

--- a/src/macOS/VoiceOver/VoiceOver.test.ts
+++ b/src/macOS/VoiceOver/VoiceOver.test.ts
@@ -376,15 +376,17 @@ describe("VoiceOver", () => {
   });
 
   describe("getSettings", () => {
+    const settingsStub = { testSetting: true };
+
     describe("when VoiceOver is not running", () => {
-      it("should throw an error", () => {
-        expect(() => vo.getSettings()).toThrow(ERR_VOICE_OVER_NOT_RUNNING);
+      it("should return the current settings", async () => {
+        jest.mocked(getPreferences).mockReturnValue(settingsStub);
+
+        expect(vo.getSettings()).toEqual(settingsStub);
       });
     });
 
     describe("when VoiceOver is running", () => {
-      const settingsStub = { testSetting: true };
-
       it("should return the current settings", async () => {
         jest.mocked(getPreferences).mockReturnValue(settingsStub);
 
@@ -398,17 +400,17 @@ describe("VoiceOver", () => {
   });
 
   describe("getSetting", () => {
+    const settingStub = "test-value";
+
     describe("when VoiceOver is not running", () => {
-      it("should throw an error", () => {
-        expect(() => vo.getSetting("test-setting")).toThrow(
-          ERR_VOICE_OVER_NOT_RUNNING,
-        );
+      it("should return the value for the setting", async () => {
+        jest.mocked(getPreference).mockReturnValue(settingStub);
+
+        expect(vo.getSetting("test-setting")).toBe(settingStub);
       });
     });
 
     describe("when VoiceOver is running", () => {
-      const settingStub = "test-value";
-
       it("should return the value for the setting", async () => {
         jest.mocked(getPreference).mockReturnValue(settingStub);
 

--- a/src/macOS/VoiceOver/VoiceOver.ts
+++ b/src/macOS/VoiceOver/VoiceOver.ts
@@ -1056,31 +1056,94 @@ export class VoiceOver implements IScreenReader {
   }
 
   /**
-   * Returns all available settings for the screen reader.
+   * [API Reference](https://www.guidepup.dev/docs/api/class-voiceover#voiceover-get-settings)
    *
-   * @returns All available settings values.
+   * Returns all the current settings for this VoiceOver instance.
+   *
+   * ```ts
+   * import { voiceOver } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start VoiceOver.
+   *   await voiceOver.start();
+   *
+   *   // Log current settings.
+   *   console.log(voiceOver.getSettings());
+   *
+   *   // Stop VoiceOver.
+   *   await voiceOver.stop();
+   * })();
+   * ```
+   *
+   * @returns {Record<string, unknown>} Current settings values.
    */
   getSettings(): Record<string, unknown> {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
+    }
+
     return getPreferences();
   }
 
   /**
-   * Returns the value of a screen reader setting.
+   * [API Reference](https://www.guidepup.dev/docs/api/class-voiceover#voiceover-get-setting)
+   *
+   * ```ts
+   * import { voiceOver } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start VoiceOver.
+   *   await voiceOver.start();
+   *
+   *   // Log the value for the 'SCRCUserDefaultsCursorTrackingEnabled' setting.
+   *   console.log(voiceOver.getSetting('SCRCUserDefaultsCursorTrackingEnabled'));
+   *
+   *   // Stop VoiceOver.
+   *   await voiceOver.stop();
+   * })();
+   * ```
+   *
+   * Returns the value of a setting for this VoiceOver instance.
    *
    * @param key The setting name.
-   * @returns The setting value.
+   * @returns {unknown} The setting value.
    */
   getSetting(key: string): unknown {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
+    }
+
     return getPreference(key);
   }
 
   /**
-   * Sets the value of a screen reader setting.
+   * [API Reference](https://www.guidepup.dev/docs/api/class-voiceover#voiceover-set-setting)
+   *
+   * ```ts
+   * import { voiceOver } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start VoiceOver.
+   *   await voiceOver.start();
+   *
+   *   // Set the 'SCRCUserDefaultsCursorTrackingEnabled' setting to false.
+   *   console.log(voiceOver.setSetting('SCRCUserDefaultsCursorTrackingEnabled', false));
+   *
+   *   // Stop VoiceOver.
+   *   await voiceOver.stop();
+   * })();
+   * ```
+   *
+   * Sets the value of a setting for this VoiceOver instance.
    *
    * @param key The setting name.
    * @param value The value to assign.
    */
   setSetting(key: string, value: unknown): void {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
+    }
+
     setPreference(key, value);
   }
 }

--- a/src/macOS/VoiceOver/VoiceOver.ts
+++ b/src/macOS/VoiceOver/VoiceOver.ts
@@ -1083,11 +1083,6 @@ export class VoiceOver implements IScreenReader {
    * @returns {Record<string, unknown>} Current settings values.
    */
   getSettings(): Record<string, unknown> {
-    if (!this.#started || this.#stopping) {
-      // TODO: get preview of the settings.
-      throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
-    }
-
     return getPreferences();
   }
 
@@ -1115,11 +1110,6 @@ export class VoiceOver implements IScreenReader {
    * @returns {unknown} The setting value.
    */
   getSetting(key: string): unknown {
-    if (!this.#started || this.#stopping) {
-      // TODO: get preview of the setting.
-      throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
-    }
-
     return getPreference(key);
   }
 }

--- a/src/macOS/VoiceOver/VoiceOver.ts
+++ b/src/macOS/VoiceOver/VoiceOver.ts
@@ -8,7 +8,7 @@ import {
   getPreference,
   getPreferences,
   mountGuidepupPreferences,
-  setPreference,
+  setPreferences,
   unmountGuidepupPreferences,
 } from "./preferences";
 import { ClickOptions } from "../../ClickOptions";
@@ -57,11 +57,6 @@ export class VoiceOver implements IScreenReader {
    * VoiceOver stopping status.
    */
   #stopping = false;
-
-  /**
-   * Settings to be applied when VoiceOver is next started.
-   */
-  #pendingSettings = {};
 
   /**
    * VoiceOver client for queued execution and log tapping.
@@ -302,12 +297,9 @@ export class VoiceOver implements IScreenReader {
     try {
       mountGuidepupPreferences();
 
-      Object.entries({
-        ...this.#pendingSettings,
-        ...options?.settings,
-      }).forEach(([key, value]) => {
-        setPreference(key, value);
-      });
+      if (options?.settings) {
+        setPreferences(options.settings);
+      }
 
       for (let attempt = 0; attempt < VoiceOver.#START_ATTEMPTS; attempt++) {
         try {
@@ -345,8 +337,6 @@ export class VoiceOver implements IScreenReader {
         }
       }
     }
-
-    this.#pendingSettings = {};
 
     this.#client = new VoiceOverClient(options);
     this.#caption = new VoiceOverCaption(this.#client);
@@ -1131,40 +1121,5 @@ export class VoiceOver implements IScreenReader {
     }
 
     return getPreference(key);
-  }
-
-  /**
-   * [API Reference](https://www.guidepup.dev/docs/api/class-voiceover#voiceover-set-setting)
-   *
-   * Sets the value of a setting for this VoiceOver instance.
-   *
-   * ```ts
-   * import { voiceOver } from "@guidepup/guidepup";
-   *
-   * (async () => {
-   *   // Start VoiceOver.
-   *   await voiceOver.start();
-   *
-   *   // Set the 'SCRCUserDefaultsCursorTrackingEnabled' setting to false.
-   *   console.log(voiceOver.setSetting('SCRCUserDefaultsCursorTrackingEnabled', false));
-   *
-   *   // Stop VoiceOver.
-   *   await voiceOver.stop();
-   * })();
-   * ```
-   *
-   * Note: Some settings must be set before or during at startup to take effect.
-   *
-   * @param key The setting name.
-   * @param value The value to assign.
-   */
-  setSetting(key: string, value: unknown): void {
-    if (!this.#started || this.#stopping) {
-      this.#pendingSettings[key] = value;
-
-      return;
-    }
-
-    setPreference(key, value);
   }
 }

--- a/src/macOS/VoiceOver/VoiceOver.ts
+++ b/src/macOS/VoiceOver/VoiceOver.ts
@@ -21,6 +21,7 @@ import { KeyboardCommand } from "../KeyboardCommand";
 import { KeyboardOptions } from "../../KeyboardOptions";
 import type { Prettify } from "../../typeHelpers";
 import { start } from "./start";
+import type { StartOptions } from "../../StartOptions";
 import { terminateVoiceOverProcess } from "./terminateVoiceOverProcess";
 import { VoiceOverCaption } from "./VoiceOverCaption";
 import { VoiceOverClient } from "./VoiceOverClient";
@@ -56,6 +57,11 @@ export class VoiceOver implements IScreenReader {
    * VoiceOver stopping status.
    */
   #stopping = false;
+
+  /**
+   * Settings to be applied when VoiceOver is next started.
+   */
+  #pendingSettings = {};
 
   /**
    * VoiceOver client for queued execution and log tapping.
@@ -282,8 +288,8 @@ export class VoiceOver implements IScreenReader {
    *
    * @param {object} [options] Additional options.
    */
-  async start(options?: CommandOptions): Promise<void> {
-    if (!(await this.detect())) {
+  async start(options?: StartOptions): Promise<void> {
+    if (!this.detect()) {
       throw new Error(ERR_VOICE_OVER_NOT_SUPPORTED);
     }
 
@@ -295,6 +301,13 @@ export class VoiceOver implements IScreenReader {
 
     try {
       mountGuidepupPreferences();
+
+      Object.entries({
+        ...this.#pendingSettings,
+        ...options?.settings,
+      }).forEach(([key, value]) => {
+        setPreference(key, value);
+      });
 
       for (let attempt = 0; attempt < VoiceOver.#START_ATTEMPTS; attempt++) {
         try {
@@ -313,8 +326,8 @@ export class VoiceOver implements IScreenReader {
           }
         }
       }
-    } catch (error) {
-      throw new Error(ERR_VOICE_OVER_CANNOT_BE_STARTED, { cause: error });
+    } catch (cause) {
+      throw new Error(ERR_VOICE_OVER_CANNOT_BE_STARTED, { cause });
     } finally {
       this.#starting = false;
 
@@ -332,6 +345,8 @@ export class VoiceOver implements IScreenReader {
         }
       }
     }
+
+    this.#pendingSettings = {};
 
     this.#client = new VoiceOverClient(options);
     this.#caption = new VoiceOverCaption(this.#client);
@@ -1079,6 +1094,7 @@ export class VoiceOver implements IScreenReader {
    */
   getSettings(): Record<string, unknown> {
     if (!this.#started || this.#stopping) {
+      // TODO: get preview of the settings.
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -1087,6 +1103,8 @@ export class VoiceOver implements IScreenReader {
 
   /**
    * [API Reference](https://www.guidepup.dev/docs/api/class-voiceover#voiceover-get-setting)
+   *
+   * Returns the value of a setting for this VoiceOver instance.
    *
    * ```ts
    * import { voiceOver } from "@guidepup/guidepup";
@@ -1103,13 +1121,12 @@ export class VoiceOver implements IScreenReader {
    * })();
    * ```
    *
-   * Returns the value of a setting for this VoiceOver instance.
-   *
    * @param key The setting name.
    * @returns {unknown} The setting value.
    */
   getSetting(key: string): unknown {
     if (!this.#started || this.#stopping) {
+      // TODO: get preview of the setting.
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
@@ -1118,6 +1135,8 @@ export class VoiceOver implements IScreenReader {
 
   /**
    * [API Reference](https://www.guidepup.dev/docs/api/class-voiceover#voiceover-set-setting)
+   *
+   * Sets the value of a setting for this VoiceOver instance.
    *
    * ```ts
    * import { voiceOver } from "@guidepup/guidepup";
@@ -1134,14 +1153,16 @@ export class VoiceOver implements IScreenReader {
    * })();
    * ```
    *
-   * Sets the value of a setting for this VoiceOver instance.
+   * Note: Some settings must be set before or during at startup to take effect.
    *
    * @param key The setting name.
    * @param value The value to assign.
    */
   setSetting(key: string, value: unknown): void {
     if (!this.#started || this.#stopping) {
-      throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
+      this.#pendingSettings[key] = value;
+
+      return;
     }
 
     setPreference(key, value);

--- a/src/macOS/VoiceOver/VoiceOver.ts
+++ b/src/macOS/VoiceOver/VoiceOver.ts
@@ -5,7 +5,10 @@ import {
   ERR_VOICE_OVER_NOT_SUPPORTED,
 } from "../errors";
 import {
+  getPreference,
+  getPreferences,
   mountGuidepupPreferences,
+  setPreference,
   unmountGuidepupPreferences,
 } from "./preferences";
 import { ClickOptions } from "../../ClickOptions";
@@ -1050,5 +1053,34 @@ export class VoiceOver implements IScreenReader {
     }
 
     await this.#caption.clearItemTextLog();
+  }
+
+  /**
+   * Returns all available settings for the screen reader.
+   *
+   * @returns All available settings values.
+   */
+  getSettings(): Record<string, unknown> {
+    return getPreferences();
+  }
+
+  /**
+   * Returns the value of a screen reader setting.
+   *
+   * @param key The setting name.
+   * @returns The setting value.
+   */
+  getSetting(key: string): unknown {
+    return getPreference(key);
+  }
+
+  /**
+   * Sets the value of a screen reader setting.
+   *
+   * @param key The setting name.
+   * @param value The value to assign.
+   */
+  setSetting(key: string, value: unknown): void {
+    setPreference(key, value);
   }
 }

--- a/src/macOS/VoiceOver/preferences/attachPortablePreferences.test.ts
+++ b/src/macOS/VoiceOver/preferences/attachPortablePreferences.test.ts
@@ -1,0 +1,53 @@
+import { attachPortablePreferences } from "./attachPortablePreferences";
+import { ERR_VOICE_OVER_FAILED_TO_MOUNT_GUIDEPUP_PREFERENCES } from "../../errors";
+import { execFileSync } from "node:child_process";
+import { MOUNT_POINT } from "./constants";
+
+jest.mock("node:child_process", () => ({
+  execFileSync: jest.fn(),
+}));
+
+describe("attachPortablePreferences", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when attaching the preferences image succeeds", () => {
+    beforeEach(() => {
+      attachPortablePreferences("test-dmg-path");
+    });
+
+    it("should attach the preferences image", () => {
+      expect(execFileSync).toHaveBeenCalledWith(
+        "/usr/bin/hdiutil",
+        [
+          "attach",
+          "test-dmg-path",
+          "-mountpoint",
+          MOUNT_POINT,
+          "-shadow",
+          "test-dmg-path.shadow",
+        ],
+        { stdio: "ignore" },
+      );
+    });
+  });
+
+  describe("when attaching the preferences image throws an error", () => {
+    const cause = new Error("test-error");
+
+    beforeEach(() => {
+      jest.mocked(execFileSync).mockImplementation(() => {
+        throw cause;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => attachPortablePreferences("test-dmg-path")).toThrow(
+        new Error(ERR_VOICE_OVER_FAILED_TO_MOUNT_GUIDEPUP_PREFERENCES, {
+          cause,
+        }),
+      );
+    });
+  });
+});

--- a/src/macOS/VoiceOver/preferences/attachPortablePreferences.ts
+++ b/src/macOS/VoiceOver/preferences/attachPortablePreferences.ts
@@ -6,7 +6,14 @@ export function attachPortablePreferences(dmgPath: string): void {
   try {
     execFileSync(
       "/usr/bin/hdiutil",
-      ["attach", dmgPath, "-mountpoint", MOUNT_POINT, "-shadow"],
+      [
+        "attach",
+        dmgPath,
+        "-mountpoint",
+        MOUNT_POINT,
+        "-shadow",
+        `${dmgPath}.shadow`,
+      ],
       { stdio: "ignore" },
     );
   } catch (cause) {

--- a/src/macOS/VoiceOver/preferences/constants.ts
+++ b/src/macOS/VoiceOver/preferences/constants.ts
@@ -2,3 +2,5 @@ export const VOLUME_NAME = "GuidepupVoiceOverPreferences";
 export const MOUNT_POINT = `/Volumes/${VOLUME_NAME}`;
 export const GUIDEPUP_IDENTIFIER =
   "4800BFDE-77D8-4A27-A8E2-90CD8CE508EA-guidepup";
+
+export const VOICEOVER_DOMAIN = "com.apple.VoiceOver4/default";

--- a/src/macOS/VoiceOver/preferences/constants.ts
+++ b/src/macOS/VoiceOver/preferences/constants.ts
@@ -1,5 +1,14 @@
+import { join } from "node:path";
+
 export const VOLUME_NAME = "GuidepupVoiceOverPreferences";
-export const MOUNT_POINT = `/Volumes/${VOLUME_NAME}`;
+export const MOUNT_POINT = join("/Volumes", VOLUME_NAME);
+export const PREFERENCES_PATH = join(
+  MOUNT_POINT,
+  "VoiceOver",
+  "VoiceOver4.portable",
+);
+export const DEFAULT_PREFERENCES = join(PREFERENCES_PATH, "default.plist");
+
 export const GUIDEPUP_IDENTIFIER =
   "4800BFDE-77D8-4A27-A8E2-90CD8CE508EA-guidepup";
 

--- a/src/macOS/VoiceOver/preferences/createPortableSymlinks.test.ts
+++ b/src/macOS/VoiceOver/preferences/createPortableSymlinks.test.ts
@@ -1,0 +1,104 @@
+import { rmSync, symlinkSync } from "node:fs";
+import { createPortableSymlinks } from "./createPortableSymlinks";
+import { ERR_VOICE_OVER_FAILED_TO_MOUNT_GUIDEPUP_PREFERENCES } from "../../errors";
+import { join } from "node:path";
+import { PREFERENCES_PATH } from "./constants";
+
+jest.mock("node:fs", () => ({
+  rmSync: jest.fn(),
+  symlinkSync: jest.fn(),
+}));
+
+jest.mock("node:path", () => ({
+  join: jest.fn(),
+}));
+
+describe("createPortableSymlinks", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest
+      .mocked(join)
+      .mockImplementation((directory, file) => `${directory}/${file}`);
+  });
+
+  describe("when called with a preferences directory", () => {
+    beforeEach(() => {
+      createPortableSymlinks("test-preferences-directory");
+    });
+
+    it("should remove existing portable preference files", () => {
+      expect(rmSync).toHaveBeenCalledWith(
+        "test-preferences-directory/com.apple.VoiceOver4.portable.scrd",
+        { force: true },
+      );
+      expect(rmSync).toHaveBeenCalledWith(
+        "test-preferences-directory/com.apple.VoiceOver4.portable.scrd.vou",
+        { force: true },
+      );
+      expect(rmSync).toHaveBeenCalledWith(
+        "test-preferences-directory/com.apple.VoiceOver4.portable.scro",
+        { force: true },
+      );
+      expect(rmSync).toHaveBeenCalledWith(
+        "test-preferences-directory/com.apple.VoiceOver4.portable.scui",
+        { force: true },
+      );
+      expect(rmSync).toHaveBeenCalledTimes(4);
+    });
+
+    it("should create symlinks for each portable preference file", () => {
+      expect(symlinkSync).toHaveBeenCalledWith(
+        PREFERENCES_PATH,
+        "test-preferences-directory/com.apple.VoiceOver4.portable.scrd",
+      );
+      expect(symlinkSync).toHaveBeenCalledWith(
+        PREFERENCES_PATH,
+        "test-preferences-directory/com.apple.VoiceOver4.portable.scrd.vou",
+      );
+      expect(symlinkSync).toHaveBeenCalledWith(
+        PREFERENCES_PATH,
+        "test-preferences-directory/com.apple.VoiceOver4.portable.scro",
+      );
+      expect(symlinkSync).toHaveBeenCalledWith(
+        PREFERENCES_PATH,
+        "test-preferences-directory/com.apple.VoiceOver4.portable.scui",
+      );
+      expect(symlinkSync).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe("when removing an existing portable preference file fails", () => {
+    beforeEach(() => {
+      jest.mocked(rmSync).mockImplementation(() => {
+        throw new Error("test-error");
+      });
+
+      createPortableSymlinks("test-preferences-directory");
+    });
+
+    it("should continue creating portable symlinks", () => {
+      expect(symlinkSync).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe("when creating a portable symlink fails", () => {
+    const cause = new Error("test-error");
+
+    beforeEach(() => {
+      jest.mocked(symlinkSync).mockImplementation(() => {
+        throw cause;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() =>
+        createPortableSymlinks("test-preferences-directory"),
+      ).toThrow(
+        new Error(ERR_VOICE_OVER_FAILED_TO_MOUNT_GUIDEPUP_PREFERENCES, {
+          cause,
+        }),
+      );
+    });
+  });
+});

--- a/src/macOS/VoiceOver/preferences/createPortableSymlinks.ts
+++ b/src/macOS/VoiceOver/preferences/createPortableSymlinks.ts
@@ -1,7 +1,7 @@
 import { rmSync, symlinkSync } from "node:fs";
 import { ERR_VOICE_OVER_FAILED_TO_MOUNT_GUIDEPUP_PREFERENCES } from "../../errors";
 import { join } from "node:path";
-import { MOUNT_POINT } from "./constants";
+import { PREFERENCES_PATH } from "./constants";
 
 const SYMLINK_FILES = [
   "com.apple.VoiceOver4.portable.scrd",
@@ -11,8 +11,6 @@ const SYMLINK_FILES = [
 ];
 
 export function createPortableSymlinks(preferencesDirectory: string): void {
-  const target = `${MOUNT_POINT}/VoiceOver/VoiceOver4.portable`;
-
   for (const file of SYMLINK_FILES) {
     const linkPath = join(preferencesDirectory, file);
 
@@ -23,7 +21,7 @@ export function createPortableSymlinks(preferencesDirectory: string): void {
     }
 
     try {
-      symlinkSync(target, linkPath);
+      symlinkSync(PREFERENCES_PATH, linkPath);
     } catch (cause) {
       throw new Error(ERR_VOICE_OVER_FAILED_TO_MOUNT_GUIDEPUP_PREFERENCES, {
         cause,

--- a/src/macOS/VoiceOver/preferences/detachPortablePreferences.test.ts
+++ b/src/macOS/VoiceOver/preferences/detachPortablePreferences.test.ts
@@ -1,0 +1,94 @@
+import { detachPortablePreferences } from "./detachPortablePreferences";
+import { execFileSync } from "node:child_process";
+import { MOUNT_POINT } from "./constants";
+import { rmSync } from "node:fs";
+
+jest.mock("node:child_process", () => ({
+  execFileSync: jest.fn(),
+}));
+
+jest.mock("node:fs", () => ({
+  rmSync: jest.fn(),
+}));
+
+const dmgPathDummy = "test-dmg-path";
+const errorDummy = new Error("test-error");
+
+describe("detachPortablePreferences", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when called with a dmg path", () => {
+    beforeEach(() => {
+      detachPortablePreferences(dmgPathDummy);
+    });
+
+    it("should detach the mounted preferences image", () => {
+      expect(execFileSync).toHaveBeenCalledWith(
+        "/usr/bin/hdiutil",
+        ["detach", MOUNT_POINT],
+        { stdio: "ignore" },
+      );
+    });
+
+    it("should remove the dmg shadow file", () => {
+      expect(rmSync).toHaveBeenCalledWith(`${dmgPathDummy}.shadow`, {
+        force: true,
+      });
+    });
+  });
+
+  describe("when detaching the preferences image fails", () => {
+    beforeEach(() => {
+      jest.mocked(execFileSync).mockImplementation(() => {
+        throw errorDummy;
+      });
+
+      detachPortablePreferences(dmgPathDummy);
+    });
+
+    it("should still remove the dmg shadow file", () => {
+      expect(rmSync).toHaveBeenCalledWith(`${dmgPathDummy}.shadow`, {
+        force: true,
+      });
+    });
+  });
+
+  describe("when removing the dmg shadow file fails", () => {
+    beforeEach(() => {
+      jest.mocked(rmSync).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should swallow the error", () => {
+      expect(() => detachPortablePreferences(dmgPathDummy)).not.toThrow();
+    });
+  });
+
+  describe("when detaching the preferences image and removing the dmg shadow file both fail", () => {
+    beforeEach(() => {
+      jest.mocked(execFileSync).mockImplementation(() => {
+        throw errorDummy;
+      });
+
+      jest.mocked(rmSync).mockImplementation(() => {
+        throw errorDummy;
+      });
+
+      detachPortablePreferences(dmgPathDummy);
+    });
+
+    it("should swallow the errors", () => {
+      expect(execFileSync).toHaveBeenCalledWith(
+        "/usr/bin/hdiutil",
+        ["detach", MOUNT_POINT],
+        { stdio: "ignore" },
+      );
+      expect(rmSync).toHaveBeenCalledWith(`${dmgPathDummy}.shadow`, {
+        force: true,
+      });
+    });
+  });
+});

--- a/src/macOS/VoiceOver/preferences/detachPortablePreferences.ts
+++ b/src/macOS/VoiceOver/preferences/detachPortablePreferences.ts
@@ -1,12 +1,21 @@
 import { execFileSync } from "node:child_process";
 import { MOUNT_POINT } from "./constants";
+import { rmSync } from "node:fs";
 
-export function detachPortablePreferences(): void {
+export function detachPortablePreferences(dmgPath): void {
   try {
     execFileSync("/usr/bin/hdiutil", ["detach", MOUNT_POINT], {
       stdio: "ignore",
     });
   } catch {
     // Swallow as already detached
+  }
+
+  const dmgShadowPath = `${dmgPath}.shadow`;
+
+  try {
+    rmSync(dmgShadowPath, { force: true });
+  } catch {
+    // Swallow
   }
 }

--- a/src/macOS/VoiceOver/preferences/ensureLocalPreferencesExist.test.ts
+++ b/src/macOS/VoiceOver/preferences/ensureLocalPreferencesExist.test.ts
@@ -1,0 +1,51 @@
+import { ensureLocalPreferencesExist } from "./ensureLocalPreferencesExist";
+import { ERR_VOICE_OVER_FAILED_TO_MOUNT_GUIDEPUP_PREFERENCES } from "../../errors";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+jest.mock("node:fs", () => ({
+  existsSync: jest.fn(),
+}));
+
+jest.mock("node:path", () => ({
+  join: jest.fn(),
+}));
+
+const preferencesDirectoryDummy = "test-preferences-directory";
+const localPreferencesPathDummy = "test-local-preferences-path";
+
+describe("ensureLocalPreferencesExist", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(join).mockReturnValue(localPreferencesPathDummy);
+  });
+
+  describe("when the local preferences file exists", () => {
+    beforeEach(() => {
+      jest.mocked(existsSync).mockReturnValue(true);
+
+      ensureLocalPreferencesExist(preferencesDirectoryDummy);
+    });
+
+    it("should check whether the local preferences file exists", () => {
+      expect(join).toHaveBeenCalledWith(
+        preferencesDirectoryDummy,
+        "com.apple.VoiceOver4.local.plist",
+      );
+      expect(existsSync).toHaveBeenCalledWith(localPreferencesPathDummy);
+    });
+  });
+
+  describe("when the local preferences file does not exist", () => {
+    beforeEach(() => {
+      jest.mocked(existsSync).mockReturnValue(false);
+    });
+
+    it("should throw an error", () => {
+      expect(() =>
+        ensureLocalPreferencesExist(preferencesDirectoryDummy),
+      ).toThrow(ERR_VOICE_OVER_FAILED_TO_MOUNT_GUIDEPUP_PREFERENCES);
+    });
+  });
+});

--- a/src/macOS/VoiceOver/preferences/getPreference.test.ts
+++ b/src/macOS/VoiceOver/preferences/getPreference.test.ts
@@ -1,0 +1,49 @@
+import { getPreference } from "./getPreference";
+import { getPreferences } from "./getPreferences";
+
+jest.mock("./getPreferences", () => ({
+  getPreferences: jest.fn(),
+}));
+
+const keyDummy = "test-key";
+const valueDummy = "test-value";
+
+describe("getPreference", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when the preference exists", () => {
+    beforeEach(() => {
+      jest.mocked(getPreferences).mockReturnValue({
+        [keyDummy]: valueDummy,
+      });
+    });
+
+    it("should return the preference value", () => {
+      expect(getPreference(keyDummy)).toBe(valueDummy);
+    });
+
+    it("should get preferences", () => {
+      getPreference(keyDummy);
+
+      expect(getPreferences).toHaveBeenCalled();
+    });
+  });
+
+  describe("when the preference does not exist", () => {
+    beforeEach(() => {
+      jest.mocked(getPreferences).mockReturnValue({});
+    });
+
+    it("should return undefined", () => {
+      expect(getPreference(keyDummy)).toBeUndefined();
+    });
+
+    it("should get preferences", () => {
+      getPreference(keyDummy);
+
+      expect(getPreferences).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/macOS/VoiceOver/preferences/getPreference.ts
+++ b/src/macOS/VoiceOver/preferences/getPreference.ts
@@ -1,5 +1,7 @@
 import { getPreferences } from "./getPreferences";
 
 export function getPreference(key: string): unknown {
-  return getPreferences()[key];
+  const preferences = getPreferences();
+
+  return preferences[key];
 }

--- a/src/macOS/VoiceOver/preferences/getPreference.ts
+++ b/src/macOS/VoiceOver/preferences/getPreference.ts
@@ -1,0 +1,5 @@
+import { getPreferences } from "./getPreferences";
+
+export function getPreference(key: string): unknown {
+  return getPreferences()[key];
+}

--- a/src/macOS/VoiceOver/preferences/getPreferences.test.ts
+++ b/src/macOS/VoiceOver/preferences/getPreferences.test.ts
@@ -1,0 +1,201 @@
+import { attachPortablePreferences } from "./attachPortablePreferences";
+import { DEFAULT_PREFERENCES } from "./constants";
+import { detachPortablePreferences } from "./detachPortablePreferences";
+import { ERR_VOICE_OVER_FAILED_TO_GET_SETTINGS } from "../../errors";
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { getPreferences } from "./getPreferences";
+import { resolveCachePath } from "../../../resolveCachePath";
+import { resolveDmgPath } from "./resolveDmgPath";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { parse } = require("plist");
+
+jest.mock("./attachPortablePreferences", () => ({
+  attachPortablePreferences: jest.fn(),
+}));
+
+jest.mock("./detachPortablePreferences", () => ({
+  detachPortablePreferences: jest.fn(),
+}));
+
+jest.mock("node:child_process", () => ({
+  execFileSync: jest.fn(),
+}));
+
+jest.mock("node:fs", () => ({
+  existsSync: jest.fn(),
+}));
+
+jest.mock("../../../resolveCachePath", () => ({
+  resolveCachePath: jest.fn(),
+}));
+
+jest.mock("./resolveDmgPath", () => ({
+  resolveDmgPath: jest.fn(),
+}));
+
+jest.mock("plist", () => ({
+  parse: jest.fn(),
+}));
+
+const cachePathDummy = "test-cache-path";
+const dmgPathDummy = "test-dmg-path";
+const xmlDummy = "test-xml";
+const preferencesDummy = {
+  testPreference: "test-value",
+};
+const errorDummy = new Error("test-error");
+
+describe("getPreferences", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(attachPortablePreferences).mockReturnValue(undefined);
+    jest.mocked(detachPortablePreferences).mockReturnValue(undefined);
+    jest.mocked(resolveCachePath).mockReturnValue(cachePathDummy);
+    jest.mocked(resolveDmgPath).mockReturnValue(dmgPathDummy);
+    jest.mocked(execFileSync).mockReturnValue(xmlDummy);
+    jest.mocked(parse).mockReturnValue(preferencesDummy);
+  });
+
+  describe("when portable preferences already exist", () => {
+    beforeEach(() => {
+      jest.mocked(existsSync).mockReturnValue(true);
+
+      getPreferences();
+    });
+
+    it("should check whether portable preferences exist", () => {
+      expect(existsSync).toHaveBeenCalledWith(DEFAULT_PREFERENCES);
+    });
+
+    it("should read the preferences plist", () => {
+      expect(execFileSync).toHaveBeenCalledWith(
+        "plutil",
+        ["-convert", "xml1", "-o", "-", DEFAULT_PREFERENCES],
+        {
+          encoding: "utf8",
+        },
+      );
+    });
+
+    it("should parse the preferences plist", () => {
+      expect(parse).toHaveBeenCalledWith(xmlDummy);
+    });
+
+    it("should not attach portable preferences", () => {
+      expect(attachPortablePreferences).not.toHaveBeenCalled();
+    });
+
+    it("should not detach portable preferences", () => {
+      expect(detachPortablePreferences).not.toHaveBeenCalled();
+    });
+
+    it("should return the parsed preferences", () => {
+      expect(getPreferences()).toEqual(preferencesDummy);
+    });
+  });
+
+  describe("when portable preferences do not exist", () => {
+    beforeEach(() => {
+      jest.mocked(existsSync).mockReturnValue(false);
+
+      getPreferences();
+    });
+
+    it("should resolve the cache path", () => {
+      expect(resolveCachePath).toHaveBeenCalled();
+    });
+
+    it("should resolve the dmg path", () => {
+      expect(resolveDmgPath).toHaveBeenCalledWith(cachePathDummy);
+    });
+
+    it("should attach portable preferences", () => {
+      expect(attachPortablePreferences).toHaveBeenCalledWith(dmgPathDummy);
+    });
+
+    it("should detach portable preferences", () => {
+      expect(detachPortablePreferences).toHaveBeenCalledWith(dmgPathDummy);
+    });
+  });
+
+  describe("when reading the preferences plist fails", () => {
+    beforeEach(() => {
+      jest.mocked(existsSync).mockReturnValue(true);
+
+      jest.mocked(execFileSync).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => getPreferences()).toThrow(
+        new Error(ERR_VOICE_OVER_FAILED_TO_GET_SETTINGS, {
+          cause: errorDummy,
+        }),
+      );
+    });
+  });
+
+  describe("when parsing the preferences plist fails", () => {
+    beforeEach(() => {
+      jest.mocked(existsSync).mockReturnValue(true);
+
+      jest.mocked(parse).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => getPreferences()).toThrow(
+        new Error(ERR_VOICE_OVER_FAILED_TO_GET_SETTINGS, {
+          cause: errorDummy,
+        }),
+      );
+    });
+  });
+
+  describe("when attaching portable preferences fails", () => {
+    beforeEach(() => {
+      jest.mocked(existsSync).mockReturnValue(false);
+
+      jest.mocked(attachPortablePreferences).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => getPreferences()).toThrow(
+        new Error(ERR_VOICE_OVER_FAILED_TO_GET_SETTINGS, {
+          cause: errorDummy,
+        }),
+      );
+    });
+
+    it("should detach portable preferences", () => {
+      try {
+        getPreferences();
+      } catch {
+        // Swallow
+      }
+
+      expect(detachPortablePreferences).toHaveBeenCalledWith(dmgPathDummy);
+    });
+  });
+
+  describe("when detaching portable preferences fails", () => {
+    beforeEach(() => {
+      jest.mocked(existsSync).mockReturnValue(false);
+
+      jest.mocked(detachPortablePreferences).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should not throw an error", () => {
+      expect(() => getPreferences()).not.toThrow();
+    });
+  });
+});

--- a/src/macOS/VoiceOver/preferences/getPreferences.ts
+++ b/src/macOS/VoiceOver/preferences/getPreferences.ts
@@ -39,7 +39,11 @@ export function getPreferences(): Record<string, unknown> {
     throw new Error(ERR_VOICE_OVER_FAILED_TO_GET_SETTINGS, { cause });
   } finally {
     if (!portablePreferencesAttached) {
-      detachPortablePreferences(dmgPath);
+      try {
+        detachPortablePreferences(dmgPath);
+      } catch {
+        // Swallow
+      }
     }
   }
 }

--- a/src/macOS/VoiceOver/preferences/getPreferences.ts
+++ b/src/macOS/VoiceOver/preferences/getPreferences.ts
@@ -1,14 +1,31 @@
+import { attachPortablePreferences } from "./attachPortablePreferences";
 import { DEFAULT_PREFERENCES } from "./constants";
+import { detachPortablePreferences } from "./detachPortablePreferences";
 import { ERR_VOICE_OVER_FAILED_TO_GET_SETTINGS } from "../../errors";
 import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolveCachePath } from "../../../resolveCachePath";
+import { resolveDmgPath } from "./resolveDmgPath";
 
 let plist;
 
 export function getPreferences(): Record<string, unknown> {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  plist ??= require("plist");
+  let portablePreferencesAttached: boolean;
+  let dmgPath: string;
 
   try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    plist ??= require("plist");
+
+    portablePreferencesAttached = existsSync(DEFAULT_PREFERENCES);
+
+    if (!portablePreferencesAttached) {
+      const cachePath = resolveCachePath();
+      dmgPath = resolveDmgPath(cachePath);
+
+      attachPortablePreferences(dmgPath);
+    }
+
     const xml = execFileSync(
       "plutil",
       ["-convert", "xml1", "-o", "-", DEFAULT_PREFERENCES],
@@ -20,5 +37,9 @@ export function getPreferences(): Record<string, unknown> {
     return plist.parse(xml) as Record<string, unknown>;
   } catch (cause) {
     throw new Error(ERR_VOICE_OVER_FAILED_TO_GET_SETTINGS, { cause });
+  } finally {
+    if (!portablePreferencesAttached) {
+      detachPortablePreferences(dmgPath);
+    }
   }
 }

--- a/src/macOS/VoiceOver/preferences/getPreferences.ts
+++ b/src/macOS/VoiceOver/preferences/getPreferences.ts
@@ -1,0 +1,16 @@
+import { ERR_VOICE_OVER_FAILED_TO_GET_SETTINGS } from "../../errors";
+import { execFileSync } from "node:child_process";
+import { parse } from "plist";
+import { VOICEOVER_DOMAIN } from "./constants";
+
+export function getPreferences(): Record<string, unknown> {
+  try {
+    const xml = execFileSync("defaults", ["export", VOICEOVER_DOMAIN, "-"], {
+      encoding: "utf8",
+    });
+
+    return parse(xml) as Record<string, unknown>;
+  } catch (cause) {
+    throw new Error(ERR_VOICE_OVER_FAILED_TO_GET_SETTINGS, { cause });
+  }
+}

--- a/src/macOS/VoiceOver/preferences/getPreferences.ts
+++ b/src/macOS/VoiceOver/preferences/getPreferences.ts
@@ -1,15 +1,23 @@
+import { DEFAULT_PREFERENCES } from "./constants";
 import { ERR_VOICE_OVER_FAILED_TO_GET_SETTINGS } from "../../errors";
 import { execFileSync } from "node:child_process";
-import { parse } from "plist";
-import { VOICEOVER_DOMAIN } from "./constants";
+
+let plist;
 
 export function getPreferences(): Record<string, unknown> {
-  try {
-    const xml = execFileSync("defaults", ["export", VOICEOVER_DOMAIN, "-"], {
-      encoding: "utf8",
-    });
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  plist ??= require("plist");
 
-    return parse(xml) as Record<string, unknown>;
+  try {
+    const xml = execFileSync(
+      "plutil",
+      ["-convert", "xml1", "-o", "-", DEFAULT_PREFERENCES],
+      {
+        encoding: "utf8",
+      },
+    );
+
+    return plist.parse(xml) as Record<string, unknown>;
   } catch (cause) {
     throw new Error(ERR_VOICE_OVER_FAILED_TO_GET_SETTINGS, { cause });
   }

--- a/src/macOS/VoiceOver/preferences/getPreferencesDirectory.test.ts
+++ b/src/macOS/VoiceOver/preferences/getPreferencesDirectory.test.ts
@@ -1,0 +1,61 @@
+import { existsSync } from "node:fs";
+import { getPreferencesDirectory } from "./getPreferencesDirectory";
+import { homedir } from "node:os";
+
+jest.mock("node:fs", () => ({
+  existsSync: jest.fn(),
+}));
+
+jest.mock("node:os", () => ({
+  homedir: jest.fn(),
+}));
+
+const homeDirectoryDummy = "test-home-directory";
+
+describe("getPreferencesDirectory", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(homedir).mockReturnValue(homeDirectoryDummy);
+  });
+
+  describe("when the VoiceOver group containers preferences directory exists", () => {
+    beforeEach(() => {
+      jest.mocked(existsSync).mockReturnValue(true);
+    });
+
+    it("should check whether the VoiceOver preferences directory exists", () => {
+      getPreferencesDirectory();
+
+      expect(existsSync).toHaveBeenCalledWith(
+        `${homeDirectoryDummy}/Library/Group Containers/group.com.apple.VoiceOver/Library/Preferences`,
+      );
+    });
+
+    it("should return the VoiceOver group containers preferences directory", () => {
+      expect(getPreferencesDirectory()).toBe(
+        `${homeDirectoryDummy}/Library/Group Containers/group.com.apple.VoiceOver/Library/Preferences`,
+      );
+    });
+  });
+
+  describe("when the VoiceOver preferences directory does not exist", () => {
+    beforeEach(() => {
+      jest.mocked(existsSync).mockReturnValue(false);
+    });
+
+    it("should check whether the VoiceOver preferences directory exists", () => {
+      getPreferencesDirectory();
+
+      expect(existsSync).toHaveBeenCalledWith(
+        `${homeDirectoryDummy}/Library/Group Containers/group.com.apple.VoiceOver/Library/Preferences`,
+      );
+    });
+
+    it("should return the legacy preferences directory", () => {
+      expect(getPreferencesDirectory()).toBe(
+        `${homeDirectoryDummy}/Library/Preferences`,
+      );
+    });
+  });
+});

--- a/src/macOS/VoiceOver/preferences/index.ts
+++ b/src/macOS/VoiceOver/preferences/index.ts
@@ -1,2 +1,5 @@
+export { getPreference } from "./getPreference";
+export { getPreferences } from "./getPreferences";
+export { setPreference } from "./setPreference";
 export { mountGuidepupPreferences } from "./mountGuidepupPreferences";
 export { unmountGuidepupPreferences } from "./unmountGuidepupPreferences";

--- a/src/macOS/VoiceOver/preferences/index.ts
+++ b/src/macOS/VoiceOver/preferences/index.ts
@@ -1,5 +1,5 @@
 export { getPreference } from "./getPreference";
 export { getPreferences } from "./getPreferences";
-export { setPreference } from "./setPreference";
+export { setPreferences } from "./setPreferences";
 export { mountGuidepupPreferences } from "./mountGuidepupPreferences";
 export { unmountGuidepupPreferences } from "./unmountGuidepupPreferences";

--- a/src/macOS/VoiceOver/preferences/mountGuidepupPreferences.test.ts
+++ b/src/macOS/VoiceOver/preferences/mountGuidepupPreferences.test.ts
@@ -1,0 +1,110 @@
+import { attachPortablePreferences } from "./attachPortablePreferences";
+import { createPortableSymlinks } from "./createPortableSymlinks";
+import { detachPortablePreferences } from "./detachPortablePreferences";
+import { ensureLocalPreferencesExist } from "./ensureLocalPreferencesExist";
+import { getPreferencesDirectory } from "./getPreferencesDirectory";
+import { mountGuidepupPreferences } from "./mountGuidepupPreferences";
+import { resolveCachePath } from "../../../resolveCachePath";
+import { resolveDmgPath } from "./resolveDmgPath";
+import { restartPreferencesDaemon } from "./restartPreferencesDaemon";
+import { trustPortableIdentifier } from "./trustPortableIdentifier";
+
+jest.mock("./attachPortablePreferences", () => ({
+  attachPortablePreferences: jest.fn(),
+}));
+
+jest.mock("./createPortableSymlinks", () => ({
+  createPortableSymlinks: jest.fn(),
+}));
+
+jest.mock("./detachPortablePreferences", () => ({
+  detachPortablePreferences: jest.fn(),
+}));
+
+jest.mock("./ensureLocalPreferencesExist", () => ({
+  ensureLocalPreferencesExist: jest.fn(),
+}));
+
+jest.mock("./getPreferencesDirectory", () => ({
+  getPreferencesDirectory: jest.fn(),
+}));
+
+jest.mock("../../../resolveCachePath", () => ({
+  resolveCachePath: jest.fn(),
+}));
+
+jest.mock("./resolveDmgPath", () => ({
+  resolveDmgPath: jest.fn(),
+}));
+
+jest.mock("./restartPreferencesDaemon", () => ({
+  restartPreferencesDaemon: jest.fn(),
+}));
+
+jest.mock("./trustPortableIdentifier", () => ({
+  trustPortableIdentifier: jest.fn(),
+}));
+
+const cachePathDummy = "test-cache-path";
+const preferencesDirectoryDummy = "test-preferences-directory";
+const dmgPathDummy = "test-dmg-path";
+
+describe("mountGuidepupPreferences", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(resolveCachePath).mockReturnValue(cachePathDummy);
+    jest
+      .mocked(getPreferencesDirectory)
+      .mockReturnValue(preferencesDirectoryDummy);
+    jest.mocked(resolveDmgPath).mockReturnValue(dmgPathDummy);
+  });
+
+  describe("when called", () => {
+    beforeEach(() => {
+      mountGuidepupPreferences();
+    });
+
+    it("should resolve the cache path", () => {
+      expect(resolveCachePath).toHaveBeenCalled();
+    });
+
+    it("should get the preferences directory", () => {
+      expect(getPreferencesDirectory).toHaveBeenCalled();
+    });
+
+    it("should ensure local preferences exist", () => {
+      expect(ensureLocalPreferencesExist).toHaveBeenCalledWith(
+        preferencesDirectoryDummy,
+      );
+    });
+
+    it("should resolve the dmg path", () => {
+      expect(resolveDmgPath).toHaveBeenCalledWith(cachePathDummy);
+    });
+
+    it("should detach existing portable preferences", () => {
+      expect(detachPortablePreferences).toHaveBeenCalledWith(dmgPathDummy);
+    });
+
+    it("should attach portable preferences", () => {
+      expect(attachPortablePreferences).toHaveBeenCalledWith(dmgPathDummy);
+    });
+
+    it("should trust the portable identifier", () => {
+      expect(trustPortableIdentifier).toHaveBeenCalledWith(
+        preferencesDirectoryDummy,
+      );
+    });
+
+    it("should create portable symlinks", () => {
+      expect(createPortableSymlinks).toHaveBeenCalledWith(
+        preferencesDirectoryDummy,
+      );
+    });
+
+    it("should restart the preferences daemon", () => {
+      expect(restartPreferencesDaemon).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/macOS/VoiceOver/preferences/mountGuidepupPreferences.ts
+++ b/src/macOS/VoiceOver/preferences/mountGuidepupPreferences.ts
@@ -14,8 +14,8 @@ export function mountGuidepupPreferences(): void {
   const preferencesDirectory = getPreferencesDirectory();
   ensureLocalPreferencesExist(preferencesDirectory);
 
-  detachPortablePreferences();
   const dmgPath = resolveDmgPath(cachePath);
+  detachPortablePreferences(dmgPath);
   attachPortablePreferences(dmgPath);
 
   trustPortableIdentifier(preferencesDirectory);

--- a/src/macOS/VoiceOver/preferences/resolveDmgPath.test.ts
+++ b/src/macOS/VoiceOver/preferences/resolveDmgPath.test.ts
@@ -1,0 +1,86 @@
+import {
+  ERR_MACOS_VERSION_NOT_SUPPORTED,
+  ERR_VOICE_OVER_FAILED_TO_MOUNT_GUIDEPUP_PREFERENCES,
+} from "../../errors";
+import { existsSync } from "node:fs";
+import { release } from "node:os";
+import { resolveDmgPath } from "./resolveDmgPath";
+
+jest.mock("node:fs", () => ({
+  existsSync: jest.fn(),
+}));
+
+jest.mock("node:os", () => ({
+  release: jest.fn(),
+}));
+
+jest.mock("../../../../manifest.json", () => ({
+  screenReaders: [
+    {
+      id: "voiceover",
+      assets: [
+        {
+          platformVersion: "123",
+          version: "test-version",
+          asset: "test-asset.dmg",
+        },
+      ],
+    },
+  ],
+}));
+
+const cachePathDummy = "test-cache-path";
+const assetPathDummy =
+  "test-cache-path/voiceover/123/test-version/test-asset.dmg";
+
+describe("resolveDmgPath", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(release).mockReturnValue("123.0.0");
+  });
+
+  describe("when a matching VoiceOver asset exists", () => {
+    beforeEach(() => {
+      jest.mocked(existsSync).mockReturnValue(true);
+
+      resolveDmgPath(cachePathDummy);
+    });
+
+    it("should get the current macOS major version", () => {
+      expect(release).toHaveBeenCalled();
+    });
+
+    it("should check that the dmg asset exists", () => {
+      expect(existsSync).toHaveBeenCalledWith(assetPathDummy);
+    });
+
+    it("should return the dmg asset path", () => {
+      expect(resolveDmgPath(cachePathDummy)).toBe(assetPathDummy);
+    });
+  });
+
+  describe("when no matching macOS version exists", () => {
+    beforeEach(() => {
+      jest.mocked(release).mockReturnValue("321.0.0");
+    });
+
+    it("should throw an error", () => {
+      expect(() => resolveDmgPath(cachePathDummy)).toThrow(
+        ERR_MACOS_VERSION_NOT_SUPPORTED,
+      );
+    });
+  });
+
+  describe("when the dmg asset does not exist", () => {
+    beforeEach(() => {
+      jest.mocked(existsSync).mockReturnValue(false);
+    });
+
+    it("should throw an error", () => {
+      expect(() => resolveDmgPath(cachePathDummy)).toThrow(
+        ERR_VOICE_OVER_FAILED_TO_MOUNT_GUIDEPUP_PREFERENCES,
+      );
+    });
+  });
+});

--- a/src/macOS/VoiceOver/preferences/restartPreferencesDaemon.test.ts
+++ b/src/macOS/VoiceOver/preferences/restartPreferencesDaemon.test.ts
@@ -1,0 +1,38 @@
+import { execFileSync } from "node:child_process";
+import { restartPreferencesDaemon } from "./restartPreferencesDaemon";
+
+jest.mock("node:child_process", () => ({
+  execFileSync: jest.fn(),
+}));
+
+describe("restartPreferencesDaemon", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when called", () => {
+    beforeEach(() => {
+      restartPreferencesDaemon();
+    });
+
+    it("should restart the preferences daemon", () => {
+      expect(execFileSync).toHaveBeenCalledWith(
+        "/usr/bin/killall",
+        ["cfprefsd"],
+        { stdio: "ignore" },
+      );
+    });
+  });
+
+  describe("when restarting the preferences daemon fails", () => {
+    beforeEach(() => {
+      jest.mocked(execFileSync).mockImplementation(() => {
+        throw new Error("test-error");
+      });
+    });
+
+    it("should swallow the error", () => {
+      expect(() => restartPreferencesDaemon()).not.toThrow();
+    });
+  });
+});

--- a/src/macOS/VoiceOver/preferences/setPreference.ts
+++ b/src/macOS/VoiceOver/preferences/setPreference.ts
@@ -1,36 +1,24 @@
-import {
-  ERR_VOICE_OVER_FAILED_TO_SET_SETTING,
-  ERR_VOICE_OVER_UNSUPPORTED_SETTING,
-} from "../../errors";
-import { execFileSync } from "node:child_process";
-import { VOICEOVER_DOMAIN } from "./constants";
+import { DEFAULT_PREFERENCES } from "./constants";
+import { ERR_VOICE_OVER_FAILED_TO_SET_SETTING } from "../../errors";
+import { getPreferences } from "./getPreferences";
+import { restartPreferencesDaemon } from "./restartPreferencesDaemon";
+import { writeFileSync } from "node:fs";
 
-function getWriteArguments(key: string, value: unknown): string[] {
-  if (typeof value === "string") {
-    return ["write", VOICEOVER_DOMAIN, key, "-string", value];
-  }
-
-  if (typeof value === "boolean") {
-    return ["write", VOICEOVER_DOMAIN, key, "-bool", value ? "YES" : "NO"];
-  }
-
-  if (typeof value === "number") {
-    return [
-      "write",
-      VOICEOVER_DOMAIN,
-      key,
-      Number.isInteger(value) ? "-int" : "-float",
-      value.toString(),
-    ];
-  }
-
-  throw new TypeError(`${ERR_VOICE_OVER_UNSUPPORTED_SETTING}${typeof value}`);
-}
+let plist;
 
 export function setPreference(key: string, value: unknown): void {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  plist ??= require("plist");
+
   try {
-    execFileSync("defaults", getWriteArguments(key, value));
+    const preferences = getPreferences();
+
+    preferences[key] = value;
+
+    writeFileSync(DEFAULT_PREFERENCES, plist.build(preferences));
   } catch (cause) {
     throw new Error(ERR_VOICE_OVER_FAILED_TO_SET_SETTING, { cause });
   }
+
+  restartPreferencesDaemon();
 }

--- a/src/macOS/VoiceOver/preferences/setPreference.ts
+++ b/src/macOS/VoiceOver/preferences/setPreference.ts
@@ -1,0 +1,36 @@
+import {
+  ERR_VOICE_OVER_FAILED_TO_SET_SETTING,
+  ERR_VOICE_OVER_UNSUPPORTED_SETTING,
+} from "../../errors";
+import { execFileSync } from "node:child_process";
+import { VOICEOVER_DOMAIN } from "./constants";
+
+function getWriteArguments(key: string, value: unknown): string[] {
+  if (typeof value === "string") {
+    return ["write", VOICEOVER_DOMAIN, key, "-string", value];
+  }
+
+  if (typeof value === "boolean") {
+    return ["write", VOICEOVER_DOMAIN, key, "-bool", value ? "YES" : "NO"];
+  }
+
+  if (typeof value === "number") {
+    return [
+      "write",
+      VOICEOVER_DOMAIN,
+      key,
+      Number.isInteger(value) ? "-int" : "-float",
+      value.toString(),
+    ];
+  }
+
+  throw new TypeError(`${ERR_VOICE_OVER_UNSUPPORTED_SETTING}${typeof value}`);
+}
+
+export function setPreference(key: string, value: unknown): void {
+  try {
+    execFileSync("defaults", getWriteArguments(key, value));
+  } catch (cause) {
+    throw new Error(ERR_VOICE_OVER_FAILED_TO_SET_SETTING, { cause });
+  }
+}

--- a/src/macOS/VoiceOver/preferences/setPreferences.test.ts
+++ b/src/macOS/VoiceOver/preferences/setPreferences.test.ts
@@ -1,0 +1,170 @@
+import { DEFAULT_PREFERENCES } from "./constants";
+import { ERR_VOICE_OVER_FAILED_TO_SET_SETTING } from "../../errors";
+import { getPreferences } from "./getPreferences";
+import { restartPreferencesDaemon } from "./restartPreferencesDaemon";
+import { setPreferences } from "./setPreferences";
+import { writeFileSync } from "node:fs";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { build } = require("plist");
+
+jest.mock("./getPreferences", () => ({
+  getPreferences: jest.fn(),
+}));
+
+jest.mock("./restartPreferencesDaemon", () => ({
+  restartPreferencesDaemon: jest.fn(),
+}));
+
+jest.mock("node:fs", () => ({
+  writeFileSync: jest.fn(),
+}));
+
+jest.mock("plist", () => ({
+  build: jest.fn(),
+}));
+
+const preferencesDummy = {
+  existingPreference: "existing-value",
+};
+const desiredPreferencesDummy = {
+  desiredPreference: "desired-value",
+};
+const updatedPreferencesDummy = {
+  existingPreference: "existing-value",
+  desiredPreference: "desired-value",
+};
+const plistDummy = "test-plist";
+const errorDummy = new Error("test-error");
+
+describe("setPreferences", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(getPreferences).mockReturnValue(preferencesDummy);
+    jest.mocked(build).mockReturnValue(plistDummy);
+  });
+
+  describe("when called with desired preferences", () => {
+    beforeEach(() => {
+      setPreferences(desiredPreferencesDummy);
+    });
+
+    it("should get the current preferences", () => {
+      expect(getPreferences).toHaveBeenCalled();
+    });
+
+    it("should build the updated preferences plist", () => {
+      expect(build).toHaveBeenCalledWith(updatedPreferencesDummy);
+    });
+
+    it("should write the updated preferences", () => {
+      expect(writeFileSync).toHaveBeenCalledWith(
+        DEFAULT_PREFERENCES,
+        plistDummy,
+      );
+    });
+
+    it("should restart the preferences daemon", () => {
+      expect(restartPreferencesDaemon).toHaveBeenCalled();
+    });
+  });
+
+  describe("when getting preferences fails", () => {
+    beforeEach(() => {
+      jest.mocked(getPreferences).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => setPreferences(desiredPreferencesDummy)).toThrow(
+        new Error(ERR_VOICE_OVER_FAILED_TO_SET_SETTING, {
+          cause: errorDummy,
+        }),
+      );
+    });
+
+    it("should not write the updated preferences", () => {
+      try {
+        setPreferences(desiredPreferencesDummy);
+      } catch {
+        // Swallow
+      }
+
+      expect(writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it("should not restart the preferences daemon", () => {
+      try {
+        setPreferences(desiredPreferencesDummy);
+      } catch {
+        // Swallow
+      }
+
+      expect(restartPreferencesDaemon).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when building the preferences plist fails", () => {
+    beforeEach(() => {
+      jest.mocked(build).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => setPreferences(desiredPreferencesDummy)).toThrow(
+        new Error(ERR_VOICE_OVER_FAILED_TO_SET_SETTING, {
+          cause: errorDummy,
+        }),
+      );
+    });
+
+    it("should not write the updated preferences", () => {
+      try {
+        setPreferences(desiredPreferencesDummy);
+      } catch {
+        // Swallow
+      }
+
+      expect(writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it("should not restart the preferences daemon", () => {
+      try {
+        setPreferences(desiredPreferencesDummy);
+      } catch {
+        // Swallow
+      }
+
+      expect(restartPreferencesDaemon).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when writing preferences fails", () => {
+    beforeEach(() => {
+      jest.mocked(writeFileSync).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => setPreferences(desiredPreferencesDummy)).toThrow(
+        new Error(ERR_VOICE_OVER_FAILED_TO_SET_SETTING, {
+          cause: errorDummy,
+        }),
+      );
+    });
+
+    it("should not restart the preferences daemon", () => {
+      try {
+        setPreferences(desiredPreferencesDummy);
+      } catch {
+        // Swallow
+      }
+
+      expect(restartPreferencesDaemon).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/macOS/VoiceOver/preferences/setPreferences.ts
+++ b/src/macOS/VoiceOver/preferences/setPreferences.ts
@@ -6,16 +6,21 @@ import { writeFileSync } from "node:fs";
 
 let plist;
 
-export function setPreference(key: string, value: unknown): void {
+export function setPreferences(
+  desiredPreferences: Record<string, unknown>,
+): void {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   plist ??= require("plist");
 
   try {
     const preferences = getPreferences();
 
-    preferences[key] = value;
+    const updatedPreferences = {
+      ...preferences,
+      ...desiredPreferences,
+    };
 
-    writeFileSync(DEFAULT_PREFERENCES, plist.build(preferences));
+    writeFileSync(DEFAULT_PREFERENCES, plist.build(updatedPreferences));
   } catch (cause) {
     throw new Error(ERR_VOICE_OVER_FAILED_TO_SET_SETTING, { cause });
   }

--- a/src/macOS/VoiceOver/preferences/setPreferences.ts
+++ b/src/macOS/VoiceOver/preferences/setPreferences.ts
@@ -1,3 +1,4 @@
+import { deepMerge } from "../../../deepMerge";
 import { DEFAULT_PREFERENCES } from "./constants";
 import { ERR_VOICE_OVER_FAILED_TO_SET_SETTING } from "../../errors";
 import { getPreferences } from "./getPreferences";
@@ -15,10 +16,7 @@ export function setPreferences(
   try {
     const preferences = getPreferences();
 
-    const updatedPreferences = {
-      ...preferences,
-      ...desiredPreferences,
-    };
+    const updatedPreferences = deepMerge(preferences, desiredPreferences);
 
     writeFileSync(DEFAULT_PREFERENCES, plist.build(updatedPreferences));
   } catch (cause) {

--- a/src/macOS/VoiceOver/preferences/trustPortableIdentifier.test.ts
+++ b/src/macOS/VoiceOver/preferences/trustPortableIdentifier.test.ts
@@ -1,0 +1,186 @@
+import { ERR_VOICE_OVER_FAILED_TO_MOUNT_GUIDEPUP_PREFERENCES } from "../../errors";
+import { execFileSync } from "node:child_process";
+import { GUIDEPUP_IDENTIFIER } from "./constants";
+import { trustPortableIdentifier } from "./trustPortableIdentifier";
+
+jest.mock("node:child_process", () => ({
+  execFileSync: jest.fn(),
+}));
+
+const preferencesDirectoryDummy = "test-preferences-directory";
+const localPlistDummy =
+  "test-preferences-directory/com.apple.VoiceOver4.local.plist";
+
+const identifiersWithoutGuidepupDummy = `Array {
+    Existing.Identifier
+}
+`;
+
+const identifiersWithGuidepupDummy = `Array {
+    Existing.Identifier
+    ${GUIDEPUP_IDENTIFIER}
+}
+`;
+
+const emptyIdentifiersDummy = "Array {\n}\n";
+
+const errorDummy = {
+  stderr: "test-error",
+};
+
+describe("trustPortableIdentifier", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when the portable identifier setting exists", () => {
+    beforeEach(() => {
+      jest
+        .mocked(execFileSync)
+        .mockReturnValue(identifiersWithoutGuidepupDummy);
+
+      trustPortableIdentifier(preferencesDirectoryDummy);
+    });
+
+    it("should read the portable identifier setting", () => {
+      expect(execFileSync).toHaveBeenCalledWith(
+        "/usr/libexec/PlistBuddy",
+        ["-c", "Print :SCRCUserDefaultsAlwaysUsePortableIDs", localPlistDummy],
+        {
+          encoding: "utf-8",
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+    });
+
+    it("should add the Guidepup identifier", () => {
+      expect(execFileSync).toHaveBeenNthCalledWith(
+        2,
+        "/usr/libexec/PlistBuddy",
+        [
+          "-c",
+          `Add :SCRCUserDefaultsAlwaysUsePortableIDs:1 string ${GUIDEPUP_IDENTIFIER}`,
+          localPlistDummy,
+        ],
+        {
+          stdio: "ignore",
+        },
+      );
+    });
+  });
+
+  describe("when the portable identifier already contains the Guidepup identifier", () => {
+    beforeEach(() => {
+      jest.mocked(execFileSync).mockReturnValue(identifiersWithGuidepupDummy);
+
+      trustPortableIdentifier(preferencesDirectoryDummy);
+    });
+
+    it("should not add the Guidepup identifier", () => {
+      expect(execFileSync).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when the portable identifier setting does not exist", () => {
+    beforeEach(() => {
+      jest
+        .mocked(execFileSync)
+        .mockImplementationOnce(() => {
+          throw {
+            stderr: "Does Not Exist",
+          };
+        })
+        .mockReturnValue("");
+
+      trustPortableIdentifier(preferencesDirectoryDummy);
+    });
+
+    it("should create the portable identifier setting", () => {
+      expect(execFileSync).toHaveBeenNthCalledWith(
+        2,
+        "/usr/libexec/PlistBuddy",
+        [
+          "-c",
+          "Add :SCRCUserDefaultsAlwaysUsePortableIDs array",
+          localPlistDummy,
+        ],
+        {
+          stdio: "ignore",
+        },
+      );
+    });
+
+    it("should add the Guidepup identifier", () => {
+      expect(execFileSync).toHaveBeenNthCalledWith(
+        3,
+        "/usr/libexec/PlistBuddy",
+        [
+          "-c",
+          `Add :SCRCUserDefaultsAlwaysUsePortableIDs:0 string ${GUIDEPUP_IDENTIFIER}`,
+          localPlistDummy,
+        ],
+        {
+          stdio: "ignore",
+        },
+      );
+    });
+  });
+
+  describe("when reading the portable identifier setting fails for another reason", () => {
+    beforeEach(() => {
+      jest.mocked(execFileSync).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => trustPortableIdentifier(preferencesDirectoryDummy)).toThrow(
+        new Error(ERR_VOICE_OVER_FAILED_TO_MOUNT_GUIDEPUP_PREFERENCES, {
+          cause: errorDummy,
+        }),
+      );
+    });
+  });
+
+  describe("when creating the portable identifier setting fails", () => {
+    beforeEach(() => {
+      jest
+        .mocked(execFileSync)
+        .mockImplementationOnce(() => {
+          throw {
+            stderr: "Does Not Exist",
+          };
+        })
+        .mockImplementation(() => {
+          throw errorDummy;
+        });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => trustPortableIdentifier(preferencesDirectoryDummy)).toThrow(
+        new Error(ERR_VOICE_OVER_FAILED_TO_MOUNT_GUIDEPUP_PREFERENCES, {
+          cause: errorDummy,
+        }),
+      );
+    });
+  });
+
+  describe("when adding the Guidepup identifier fails", () => {
+    beforeEach(() => {
+      jest
+        .mocked(execFileSync)
+        .mockReturnValueOnce(emptyIdentifiersDummy)
+        .mockImplementation(() => {
+          throw errorDummy;
+        });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => trustPortableIdentifier(preferencesDirectoryDummy)).toThrow(
+        new Error(ERR_VOICE_OVER_FAILED_TO_MOUNT_GUIDEPUP_PREFERENCES, {
+          cause: errorDummy,
+        }),
+      );
+    });
+  });
+});

--- a/src/macOS/VoiceOver/preferences/unmountGuidepupPreferences.test.ts
+++ b/src/macOS/VoiceOver/preferences/unmountGuidepupPreferences.test.ts
@@ -1,0 +1,40 @@
+import { detachPortablePreferences } from "./detachPortablePreferences";
+import { resolveCachePath } from "../../../resolveCachePath";
+import { resolveDmgPath } from "./resolveDmgPath";
+import { unmountGuidepupPreferences } from "./unmountGuidepupPreferences";
+
+jest.mock("./detachPortablePreferences", () => ({
+  detachPortablePreferences: jest.fn(),
+}));
+jest.mock("../../../resolveCachePath", () => ({
+  resolveCachePath: jest.fn(),
+}));
+jest.mock("./resolveDmgPath", () => ({
+  resolveDmgPath: jest.fn(),
+}));
+
+const cachePathDummy = "test-cache-path";
+const dmgPathDummy = "test-dmg-path";
+
+describe("unmountGuidepupPreferences", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(resolveCachePath).mockReturnValue(cachePathDummy);
+    jest.mocked(resolveDmgPath).mockReturnValue(dmgPathDummy);
+
+    unmountGuidepupPreferences();
+  });
+
+  it("should resolve the cache path", () => {
+    expect(resolveCachePath).toHaveBeenCalled();
+  });
+
+  it("should resolve the dmg path", () => {
+    expect(resolveDmgPath).toHaveBeenCalledWith(cachePathDummy);
+  });
+
+  it("should detach portable preferences", () => {
+    expect(detachPortablePreferences).toHaveBeenCalledWith(dmgPathDummy);
+  });
+});

--- a/src/macOS/VoiceOver/preferences/unmountGuidepupPreferences.ts
+++ b/src/macOS/VoiceOver/preferences/unmountGuidepupPreferences.ts
@@ -1,5 +1,10 @@
 import { detachPortablePreferences } from "./detachPortablePreferences";
+import { resolveCachePath } from "../../../resolveCachePath";
+import { resolveDmgPath } from "./resolveDmgPath";
 
 export function unmountGuidepupPreferences(): void {
-  detachPortablePreferences();
+  const cachePath = resolveCachePath();
+  const dmgPath = resolveDmgPath(cachePath);
+
+  detachPortablePreferences(dmgPath);
 }

--- a/src/macOS/errors.ts
+++ b/src/macOS/errors.ts
@@ -34,8 +34,6 @@ export const ERR_VOICE_OVER_FAILED_TO_GET_SETTINGS =
   "Failed to get VoiceOver settings";
 export const ERR_VOICE_OVER_FAILED_TO_SET_SETTING =
   "Failed to set VoiceOver setting";
-export const ERR_VOICE_OVER_UNSUPPORTED_SETTING =
-  "Unsupported VoiceOver setting: ";
 
 export const ERR_PREFIX_ACTIVATE = "Unable to activate application: ";
 export const ERR_PREFIX_SEND_KEYS = "Unable to send keys: ";

--- a/src/macOS/errors.ts
+++ b/src/macOS/errors.ts
@@ -30,6 +30,13 @@ export const ERR_VOICE_OVER_GET_ITEM_TEXT =
 export const ERR_VOICE_OVER_TAKE_SCREENSHOT =
   "VoiceOver unable to take a screenshot";
 
+export const ERR_VOICE_OVER_FAILED_TO_GET_SETTINGS =
+  "Failed to get VoiceOver settings";
+export const ERR_VOICE_OVER_FAILED_TO_SET_SETTING =
+  "Failed to set VoiceOver setting";
+export const ERR_VOICE_OVER_UNSUPPORTED_SETTING =
+  "Unsupported VoiceOver setting: ";
+
 export const ERR_PREFIX_ACTIVATE = "Unable to activate application: ";
 export const ERR_PREFIX_SEND_KEYS = "Unable to send keys: ";
 export const ERR_PREFIX_QUIT = "Unable to quit application: ";

--- a/src/windows/NVDA/NVDA.test.ts
+++ b/src/windows/NVDA/NVDA.test.ts
@@ -1,4 +1,8 @@
-import { ERR_NVDA_ALREADY_RUNNING, ERR_NVDA_NOT_RUNNING } from "../errors";
+import {
+  ERR_NVDA_ALREADY_RUNNING,
+  ERR_NVDA_NOT_INSTALLED,
+  ERR_NVDA_NOT_RUNNING,
+} from "../errors";
 import { delay } from "../../delay";
 import { isNVDAInstalled } from "./isNVDAInstalled";
 import { isWindows } from "../isWindows";
@@ -7,6 +11,13 @@ import { NVDAClient } from "./NVDAClient";
 import { quit } from "./quit";
 import { start } from "./start";
 
+jest.mock("./config", () => ({
+  createGuidepupConfig: jest.fn(),
+  deleteGuidepupConfig: jest.fn(),
+  getConfig: jest.fn(),
+  getConfigKey: jest.fn(),
+  setConfig: jest.fn(),
+}));
 jest.mock("./isNVDAInstalled", () => ({
   isNVDAInstalled: jest.fn(),
 }));
@@ -53,7 +64,7 @@ describe("NVDA", () => {
   });
 
   describe("detect", () => {
-    describe("when Windows and NVDA is installed", () => {
+    describe("when on Windows", () => {
       it("should return true", () => {
         nvda = new NVDA();
 
@@ -63,21 +74,7 @@ describe("NVDA", () => {
       });
     });
 
-    describe("when Windows and NVDA is not installed", () => {
-      beforeEach(() => {
-        jest.mocked(isNVDAInstalled).mockReturnValue(false);
-      });
-
-      it("should return false", () => {
-        nvda = new NVDA();
-
-        const result = nvda.detect();
-
-        expect(result).toBe(false);
-      });
-    });
-
-    describe("when not Windows", () => {
+    describe("when not on Windows", () => {
       beforeEach(() => {
         jest.mocked(isWindows).mockReturnValue(false);
       });
@@ -107,16 +104,24 @@ describe("NVDA", () => {
 
     describe("when NVDA is already running", () => {
       beforeEach(async () => {
-        jest.mocked(start).mockResolvedValue(undefined);
-
         await nvda.start();
-
-        jest.clearAllMocks();
       });
 
       it("should throw an error", async () => {
         await expect(async () => await nvda.start()).rejects.toThrow(
           ERR_NVDA_ALREADY_RUNNING,
+        );
+      });
+    });
+
+    describe("when NVDA is not installed", () => {
+      beforeEach(async () => {
+        jest.mocked(isNVDAInstalled).mockReturnValue(false);
+      });
+
+      it("should throw an error", async () => {
+        await expect(async () => await nvda.start()).rejects.toThrow(
+          ERR_NVDA_NOT_INSTALLED,
         );
       });
     });

--- a/src/windows/NVDA/NVDA.ts
+++ b/src/windows/NVDA/NVDA.ts
@@ -746,31 +746,90 @@ export class NVDA implements IScreenReader {
   }
 
   /**
-   * Returns all available settings for the screen reader.
+   * Returns all the current settings for this NVDA instance.
    *
-   * @returns All available settings values.
+   * ```ts
+   * import { nvda } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start NVDA.
+   *   await nvda.start();
+   *
+   *   // Log current settings.
+   *   console.log(nvda.getSettings());
+   *
+   *   // Stop NVDA.
+   *   await nvda.stop();
+   * })();
+   * ```
+   *
+   * @returns {Record<string, unknown>} Current settings values.
    */
   getSettings(): Record<string, unknown> {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_NVDA_NOT_RUNNING);
+    }
+
     notImplemented();
   }
 
   /**
-   * Returns the value of a screen reader setting.
+   * Returns the value of a setting for this NVDA instance.
+   *
+   * ```ts
+   * import { nvda } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start NVDA.
+   *   await nvda.start();
+   *
+   *   // Log the value for the 'virtualBuffers.autoSayAllOnPageLoad' setting.
+   *   console.log(nvda.getSetting('virtualBuffers.autoSayAllOnPageLoad'));
+   *
+   *   // Stop NVDA.
+   *   await nvda.stop();
+   * })();
+   * ```
    *
    * @param key The setting name.
-   * @returns The setting value.
+   * @returns {unknown} The setting value.
    */
-  getSetting(): unknown {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getSetting(key: string): unknown {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_NVDA_NOT_RUNNING);
+    }
+
     notImplemented();
   }
 
   /**
-   * Sets the value of a screen reader setting.
+   * Sets the value of a setting for this NVDA instance.
+   *
+   * ```ts
+   * import { nvda } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start NVDA.
+   *   await nvda.start();
+   *
+   *   // Set the 'virtualBuffers.autoSayAllOnPageLoad' setting to true.
+   *   console.log(nvda.setSetting('virtualBuffers.autoSayAllOnPageLoad', true));
+   *
+   *   // Stop NVDA.
+   *   await nvda.stop();
+   * })();
+   * ```
    *
    * @param key The setting name.
    * @param value The value to assign.
    */
-  setSetting(): void {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  setSetting(key: string, value: unknown): void {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_NVDA_NOT_RUNNING);
+    }
+
     notImplemented();
   }
 }

--- a/src/windows/NVDA/NVDA.ts
+++ b/src/windows/NVDA/NVDA.ts
@@ -50,11 +50,6 @@ export class NVDA implements IScreenReader {
   #stopping = false;
 
   /**
-   * Settings to be applied when NVDA is next started.
-   */
-  #pendingSettings = {};
-
-  /**
    * The screen reader name.
    */
   get name(): string {
@@ -211,10 +206,7 @@ export class NVDA implements IScreenReader {
     this.#starting = true;
 
     try {
-      // Object.entries({
-      //   ...this.#pendingSettings,
-      //   ...options?.settings,
-      // }).forEach(([key, value]) => {
+      // Object.entries(options?.settings).forEach(([key, value]) => {
       //   setConfig(key, value)
       // });
 
@@ -245,8 +237,6 @@ export class NVDA implements IScreenReader {
         }
       }
     }
-
-    this.#pendingSettings = {};
   }
 
   /**
@@ -840,37 +830,6 @@ export class NVDA implements IScreenReader {
   getSetting(key: string): unknown {
     if (!this.#started || this.#stopping) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
-    }
-
-    notImplemented();
-  }
-
-  /**
-   * Sets the value of a setting for this NVDA instance.
-   *
-   * ```ts
-   * import { nvda } from "@guidepup/guidepup";
-   *
-   * (async () => {
-   *   // Start NVDA.
-   *   await nvda.start();
-   *
-   *   // Set the 'virtualBuffers.autoSayAllOnPageLoad' setting to true.
-   *   console.log(nvda.setSetting('virtualBuffers.autoSayAllOnPageLoad', true));
-   *
-   *   // Stop NVDA.
-   *   await nvda.stop();
-   * })();
-   * ```
-   *
-   * @param key The setting name.
-   * @param value The value to assign.
-   */
-  setSetting(key: string, value: unknown): void {
-    if (!this.#started || this.#stopping) {
-      this.#pendingSettings[key] = value;
-
-      return;
     }
 
     notImplemented();

--- a/src/windows/NVDA/NVDA.ts
+++ b/src/windows/NVDA/NVDA.ts
@@ -1,6 +1,14 @@
 import {
+  createGuidepupConfig,
+  deleteGuidepupConfig,
+  getConfig,
+  getConfigKey,
+  setConfig,
+} from "./config";
+import {
   ERR_NVDA_ALREADY_RUNNING,
   ERR_NVDA_CANNOT_BE_STARTED,
+  ERR_NVDA_NOT_INSTALLED,
   ERR_NVDA_NOT_RUNNING,
   ERR_NVDA_NOT_SUPPORTED,
 } from "../errors";
@@ -13,7 +21,6 @@ import type { KeyCodeCommand } from "../KeyCodeCommand";
 import { keyCodeCommands } from "./keyCodeCommands";
 import { KeyCodes } from "../KeyCodes";
 import { Modifiers } from "../Modifiers";
-import { notImplemented } from "../../notImplemented";
 import { NVDAClient } from "./NVDAClient";
 import { parseKey } from "../../parseKey";
 import type { Prettify } from "../../typeHelpers";
@@ -100,7 +107,7 @@ export class NVDA implements IScreenReader {
    * @returns {boolean}
    */
   static detect(): boolean {
-    return isWindows() && isNVDAInstalled();
+    return isWindows();
   }
 
   /**
@@ -199,6 +206,10 @@ export class NVDA implements IScreenReader {
       throw new Error(ERR_NVDA_NOT_SUPPORTED);
     }
 
+    if (!isNVDAInstalled()) {
+      throw new Error(ERR_NVDA_NOT_INSTALLED);
+    }
+
     if (this.#started || this.#starting) {
       throw new Error(ERR_NVDA_ALREADY_RUNNING);
     }
@@ -206,9 +217,11 @@ export class NVDA implements IScreenReader {
     this.#starting = true;
 
     try {
-      // Object.entries(options?.settings).forEach(([key, value]) => {
-      //   setConfig(key, value)
-      // });
+      createGuidepupConfig();
+
+      if (options?.settings) {
+        setConfig(options.settings);
+      }
 
       await start();
 
@@ -232,6 +245,12 @@ export class NVDA implements IScreenReader {
 
         try {
           quit();
+        } catch {
+          // Swallow
+        }
+
+        try {
+          deleteGuidepupConfig();
         } catch {
           // Swallow
         }
@@ -798,11 +817,7 @@ export class NVDA implements IScreenReader {
    * @returns {Record<string, unknown>} Current settings values.
    */
   getSettings(): Record<string, unknown> {
-    if (!this.#started || this.#stopping) {
-      throw new Error(ERR_NVDA_NOT_RUNNING);
-    }
-
-    notImplemented();
+    return getConfig();
   }
 
   /**
@@ -826,12 +841,7 @@ export class NVDA implements IScreenReader {
    * @param key The setting name.
    * @returns {unknown} The setting value.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   getSetting(key: string): unknown {
-    if (!this.#started || this.#stopping) {
-      throw new Error(ERR_NVDA_NOT_RUNNING);
-    }
-
-    notImplemented();
+    return getConfigKey(key);
   }
 }

--- a/src/windows/NVDA/NVDA.ts
+++ b/src/windows/NVDA/NVDA.ts
@@ -1,5 +1,6 @@
 import {
   ERR_NVDA_ALREADY_RUNNING,
+  ERR_NVDA_CANNOT_BE_STARTED,
   ERR_NVDA_NOT_RUNNING,
   ERR_NVDA_NOT_SUPPORTED,
 } from "../errors";
@@ -19,8 +20,10 @@ import type { Prettify } from "../../typeHelpers";
 import { quit } from "./quit";
 import { sendKeys } from "../sendKeys";
 import { start } from "./start";
+import type { StartOptions } from "../../StartOptions";
 
 type CaptureCommandOptions = Prettify<Pick<CommandOptions, "capture">>;
+type CaptureStartOptions = Prettify<Pick<StartOptions, "capture" | "settings">>;
 
 /**
  * Class for controlling the NVDA screen reader on Windows.
@@ -37,9 +40,19 @@ export class NVDA implements IScreenReader {
   #started = false;
 
   /**
+   * NVDA startup status.
+   */
+  #starting = false;
+
+  /**
    * NVDA stopping status.
    */
   #stopping = false;
+
+  /**
+   * Settings to be applied when NVDA is next started.
+   */
+  #pendingSettings = {};
 
   /**
    * The screen reader name.
@@ -186,25 +199,54 @@ export class NVDA implements IScreenReader {
    * capture set `{ capture: true }`, or to disable capture set
    * `{ capture: false }`.
    */
-  async start(options?: CaptureCommandOptions): Promise<void> {
-    if (!(await this.detect())) {
+  async start(options?: CaptureStartOptions): Promise<void> {
+    if (!this.detect()) {
       throw new Error(ERR_NVDA_NOT_SUPPORTED);
     }
 
-    if (this.#started) {
+    if (this.#started || this.#starting) {
       throw new Error(ERR_NVDA_ALREADY_RUNNING);
     }
 
-    // TODO: handle failures in the following steps more gracefully, we should
-    // look to gracefully reset back to default if fail to start rather than
-    // leave a half setup state.
+    this.#starting = true;
 
-    await start();
+    try {
+      // Object.entries({
+      //   ...this.#pendingSettings,
+      //   ...options?.settings,
+      // }).forEach(([key, value]) => {
+      //   setConfig(key, value)
+      // });
 
-    this.#client = new NVDAClient();
-    await this.#client.connect(options);
+      await start();
 
-    this.#started = true;
+      this.#client = new NVDAClient();
+      await this.#client.connect(options);
+
+      this.#started = true;
+    } catch (cause) {
+      throw new Error(ERR_NVDA_CANNOT_BE_STARTED, { cause });
+    } finally {
+      this.#starting = false;
+
+      if (!this.#started) {
+        try {
+          await this.#client.stop();
+        } catch {
+          // Swallow
+        }
+
+        this.#client = null;
+
+        try {
+          quit();
+        } catch {
+          // Swallow
+        }
+      }
+    }
+
+    this.#pendingSettings = {};
   }
 
   /**
@@ -824,10 +866,11 @@ export class NVDA implements IScreenReader {
    * @param key The setting name.
    * @param value The value to assign.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setSetting(key: string, value: unknown): void {
     if (!this.#started || this.#stopping) {
-      throw new Error(ERR_NVDA_NOT_RUNNING);
+      this.#pendingSettings[key] = value;
+
+      return;
     }
 
     notImplemented();

--- a/src/windows/NVDA/NVDA.ts
+++ b/src/windows/NVDA/NVDA.ts
@@ -12,6 +12,7 @@ import type { KeyCodeCommand } from "../KeyCodeCommand";
 import { keyCodeCommands } from "./keyCodeCommands";
 import { KeyCodes } from "../KeyCodes";
 import { Modifiers } from "../Modifiers";
+import { notImplemented } from "../../notImplemented";
 import { NVDAClient } from "./NVDAClient";
 import { parseKey } from "../../parseKey";
 import type { Prettify } from "../../typeHelpers";
@@ -742,5 +743,34 @@ export class NVDA implements IScreenReader {
     }
 
     await this.#client.clearSpokenPhraseLog();
+  }
+
+  /**
+   * Returns all available settings for the screen reader.
+   *
+   * @returns All available settings values.
+   */
+  getSettings(): Record<string, unknown> {
+    notImplemented();
+  }
+
+  /**
+   * Returns the value of a screen reader setting.
+   *
+   * @param key The setting name.
+   * @returns The setting value.
+   */
+  getSetting(): unknown {
+    notImplemented();
+  }
+
+  /**
+   * Sets the value of a screen reader setting.
+   *
+   * @param key The setting name.
+   * @param value The value to assign.
+   */
+  setSetting(): void {
+    notImplemented();
   }
 }

--- a/src/windows/NVDA/config/buildIni.test.ts
+++ b/src/windows/NVDA/config/buildIni.test.ts
@@ -1,0 +1,226 @@
+import { buildIni } from "./buildIni";
+
+const topLevelPrimitivesInput = {
+  a: "string",
+  b: 123,
+  c: true,
+  d: undefined,
+  e: null,
+  f: Symbol("symbol"),
+  g: BigInt(456),
+};
+
+const topLevelPrimitivesResult = `a = string
+b = 123
+c = True
+d = undefined
+e = null
+f = Symbol(symbol)
+g = "456"`;
+
+const arrayInput = {
+  a: [],
+  b: ["first", "second"],
+  c: [1, 2],
+  d: ["first", 2],
+};
+
+const arrayResult = `a = ,
+b = first,second,
+c = 1,2,
+d = first,2,`;
+
+const invalidObjectsInput = {
+  a: function a() {},
+  b: () => {},
+};
+
+const invalidObjectsResult = `a = "function a() { }"
+b = "() => { }"`;
+
+const nestedKeysInput = {
+  a: "top level key",
+  b: {
+    c: "nested key",
+    d: {
+      e: "double nested key",
+      f: {
+        g: "triple nested key",
+      },
+      h: {
+        i: "another triple nested key",
+      },
+    },
+  },
+  j: {
+    k: "another nested key",
+  },
+};
+
+const nestedKeysResult = `a = "top level key"
+[b]
+\tc = "nested key"
+\t[[d]]
+\t\te = "double nested key"
+\t\t[[[f]]]
+\t\t\tg = "triple nested key"
+\t\t[[[h]]]
+\t\t\ti = "another triple nested key"
+[j]
+\tk = "another nested key"`;
+
+const realWorldInput = {
+  schemaVersion: 22,
+  development: {},
+  screenCurtain: {
+    warnOnLoad: true,
+    playToggleSounds: true,
+  },
+  update: {
+    allowUsageStats: false,
+    askedAllowUsageStats: true,
+    autoCheck: false,
+    startupNotification: false,
+  },
+  addonStore: {
+    automaticUpdates: "disabled",
+    allowIncompatibleUpdates: false,
+    defaultUpdateChannel: 2,
+  },
+  general: {
+    showWelcomeDialogAtStartup: false,
+    language: "Windows",
+    saveConfigurationOnExit: false,
+    askToExit: false,
+    playStartAndExitSounds: false,
+    loggingLevel: "OFF",
+    preventDisplayTurningOff: true,
+  },
+  speech: {
+    synth: "oneCore",
+    oneCore: {
+      voice:
+        "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Speech_OneCore\\Voices\\Tokens\\MSTTS_V110_enGB_GeorgeM",
+      volume: 100,
+      rate: 100,
+      rateBoost: true,
+    },
+  },
+  braille: {
+    noBraille: {},
+  },
+  vision: {
+    NVDAHighlighter: {
+      highlightFocus: true,
+      highlightNavigator: true,
+      highlightBrowseMode: true,
+      enabled: true,
+    },
+  },
+  speechViewer: {
+    x: 0,
+    y: 0,
+    width: 500,
+    height: 500,
+    displays: ["(1920, 1080)"],
+    autoPositionWindow: true,
+    showSpeechViewerAtStartup: true,
+  },
+  virtualBuffers: {
+    autoSayAllOnPageLoad: false,
+  },
+  uwpOcr: {
+    language: "en-GB",
+  },
+};
+
+const realWorldResult = `schemaVersion = 22
+[development]
+[screenCurtain]
+\twarnOnLoad = True
+\tplayToggleSounds = True
+[update]
+\tallowUsageStats = False
+\taskedAllowUsageStats = True
+\tautoCheck = False
+\tstartupNotification = False
+[addonStore]
+\tautomaticUpdates = disabled
+\tallowIncompatibleUpdates = False
+\tdefaultUpdateChannel = 2
+[general]
+\tshowWelcomeDialogAtStartup = False
+\tlanguage = Windows
+\tsaveConfigurationOnExit = False
+\taskToExit = False
+\tplayStartAndExitSounds = False
+\tloggingLevel = OFF
+\tpreventDisplayTurningOff = True
+[speech]
+\tsynth = oneCore
+\t[[oneCore]]
+\t\tvoice = HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Speech_OneCore\\Voices\\Tokens\\MSTTS_V110_enGB_GeorgeM
+\t\tvolume = 100
+\t\trate = 100
+\t\trateBoost = True
+[braille]
+\t[[noBraille]]
+[vision]
+\t[[NVDAHighlighter]]
+\t\thighlightFocus = True
+\t\thighlightNavigator = True
+\t\thighlightBrowseMode = True
+\t\tenabled = True
+[speechViewer]
+\tx = 0
+\ty = 0
+\twidth = 500
+\theight = 500
+\tdisplays = "(1920, 1080)",
+\tautoPositionWindow = True
+\tshowSpeechViewerAtStartup = True
+[virtualBuffers]
+\tautoSayAllOnPageLoad = False
+[uwpOcr]
+\tlanguage = en-GB`;
+
+// @ts-expect-error deliberate repeated keys
+const repeatedInput = { a: 123, a: "string" };
+const repeatedResult = "a = string";
+
+// @ts-expect-error deliberate repeated keys
+const repeatedNestedInput = { a: 123, a: { b: "string" } };
+const repeatedNestedResult = "[a]\n\tb = string";
+
+const quotingInput = {
+  a: "contains space",
+  b: "contains\twhitespace",
+  c: "123",
+  d: "True",
+  e: "",
+};
+
+const quotingResult = `a = "contains space"
+b = "contains\twhitespace"
+c = "123"
+d = "True"
+e = ""`;
+
+describe("buildIni", () => {
+  it.each`
+    description                               | input                      | expectedResult
+    ${"undefined"}                            | ${undefined}               | ${""}
+    ${"null"}                                 | ${null}                    | ${""}
+    ${"empty"}                                | ${{}}                      | ${""}
+    ${"top level keys with primitive values"} | ${topLevelPrimitivesInput} | ${topLevelPrimitivesResult}
+    ${"arrays"}                               | ${arrayInput}              | ${arrayResult}
+    ${"invalid objects"}                      | ${invalidObjectsInput}     | ${invalidObjectsResult}
+    ${"nested keys"}                          | ${nestedKeysInput}         | ${nestedKeysResult}
+    ${"real world"}                           | ${realWorldInput}          | ${realWorldResult}
+    ${"repeated"}                             | ${repeatedInput}           | ${repeatedResult}
+    ${"repeated nested"}                      | ${repeatedNestedInput}     | ${repeatedNestedResult}
+    ${"quoted"}                               | ${quotingInput}            | ${quotingResult}
+  `("$description", ({ input, expectedResult }) => {
+    expect(buildIni(input)).toEqual(expectedResult);
+  });
+});

--- a/src/windows/NVDA/config/buildIni.ts
+++ b/src/windows/NVDA/config/buildIni.ts
@@ -1,0 +1,37 @@
+function isSection(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === "boolean") {
+    return value ? "True" : "False";
+  }
+
+  if (Array.isArray(value)) {
+    return `${value.join(",")},`;
+  }
+
+  return String(value);
+}
+
+function writeSection(
+  section: Record<string, unknown>,
+  depth: number,
+): string[] {
+  const lines: string[] = [];
+
+  for (const [key, value] of Object.entries(section)) {
+    if (isSection(value)) {
+      lines.push(`${"[".repeat(depth + 1)}${key}${"]".repeat(depth + 1)}`);
+      lines.push(...writeSection(value, depth + 1));
+    } else {
+      lines.push(`${key} = ${formatValue(value)}`);
+    }
+  }
+
+  return lines;
+}
+
+export function buildIni(config: Record<string, unknown>): string {
+  return writeSection(config, 0).join("\n");
+}

--- a/src/windows/NVDA/config/buildIni.ts
+++ b/src/windows/NVDA/config/buildIni.ts
@@ -14,7 +14,7 @@ function shouldQuote(value: string): boolean {
 }
 
 function quoteIniString(value: string): string {
-  return `"${value.replace(/"/g, '\\"')}"`;
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
 function formatValue(value: unknown): string {

--- a/src/windows/NVDA/config/buildIni.ts
+++ b/src/windows/NVDA/config/buildIni.ts
@@ -2,16 +2,41 @@ function isSection(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function shouldQuote(value: string): boolean {
+  return (
+    value.length === 0 ||
+    /^\s|\s$/.test(value) ||
+    /[\s#;=]/.test(value) ||
+    /"/.test(value) ||
+    /^-?\d+(\.\d+)?$/.test(value) ||
+    /^(True|False)$/.test(value)
+  );
+}
+
+function quoteIniString(value: string): string {
+  return `"${value.replace(/"/g, '\\"')}"`;
+}
+
 function formatValue(value: unknown): string {
   if (typeof value === "boolean") {
     return value ? "True" : "False";
   }
 
-  if (Array.isArray(value)) {
-    return `${value.join(",")},`;
+  if (typeof value === "number") {
+    return String(value);
   }
 
-  return String(value);
+  if (Array.isArray(value)) {
+    return `${value.map((subValue) => formatValue(subValue)).join(",")},`;
+  }
+
+  const unquotedString = String(value);
+
+  if (shouldQuote(unquotedString)) {
+    return quoteIniString(unquotedString);
+  }
+
+  return unquotedString;
 }
 
 function writeSection(
@@ -20,12 +45,14 @@ function writeSection(
 ): string[] {
   const lines: string[] = [];
 
-  for (const [key, value] of Object.entries(section)) {
+  for (const [key, value] of Object.entries(section ?? {})) {
     if (isSection(value)) {
-      lines.push(`${"[".repeat(depth + 1)}${key}${"]".repeat(depth + 1)}`);
+      lines.push(
+        `${"\t".repeat(depth)}${"[".repeat(depth + 1)}${key}${"]".repeat(depth + 1)}`,
+      );
       lines.push(...writeSection(value, depth + 1));
     } else {
-      lines.push(`${key} = ${formatValue(value)}`);
+      lines.push(`${"\t".repeat(depth)}${key} = ${formatValue(value)}`);
     }
   }
 

--- a/src/windows/NVDA/config/createGuidepupConfig.test.ts
+++ b/src/windows/NVDA/config/createGuidepupConfig.test.ts
@@ -1,0 +1,194 @@
+import { cpSync, existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import {
+  ERR_NVDA_FAILED_TO_CREATE_GUIDEPUP_PREFERENCES,
+  ERR_NVDA_NOT_INSTALLED,
+} from "../../errors";
+import { createGuidepupConfig } from "./createGuidepupConfig";
+import { resolveGuidepupUserConfigPath } from "./resolveGuidepupUserConfigPath";
+import { resolveSessionUserConfigPath } from "./resolveSessionUserConfigPath";
+
+jest.mock("node:fs", () => ({
+  cpSync: jest.fn(),
+  existsSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  readdirSync: jest.fn(),
+  rmSync: jest.fn(),
+}));
+
+jest.mock("./resolveGuidepupUserConfigPath", () => ({
+  resolveGuidepupUserConfigPath: jest.fn(),
+}));
+
+jest.mock("./resolveSessionUserConfigPath", () => ({
+  resolveSessionUserConfigPath: jest.fn(),
+}));
+
+const guidepupUserConfigPathDummy = "test-guidepup-user-config";
+const sessionUserConfigPathDummy = "test-session-user-config";
+const entriesDummy = ["config", "state.ini"] as unknown as ReturnType<
+  typeof readdirSync
+>;
+
+const errorDummy = new Error("test-error");
+
+describe("createGuidepupConfig", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest
+      .mocked(resolveGuidepupUserConfigPath)
+      .mockReturnValue(guidepupUserConfigPathDummy);
+
+    jest
+      .mocked(resolveSessionUserConfigPath)
+      .mockReturnValue(sessionUserConfigPathDummy);
+
+    jest.mocked(existsSync).mockReturnValue(true);
+    jest.mocked(readdirSync).mockReturnValue(entriesDummy);
+  });
+
+  describe("when Guidepup user config does not exist", () => {
+    beforeEach(() => {
+      jest.mocked(existsSync).mockReturnValue(false);
+    });
+
+    it("should throw an error", () => {
+      expect(() => createGuidepupConfig()).toThrow(ERR_NVDA_NOT_INSTALLED);
+    });
+  });
+
+  describe("when Guidepup user config exists", () => {
+    beforeEach(() => {
+      createGuidepupConfig();
+    });
+
+    it("should remove the existing session user config", () => {
+      expect(rmSync).toHaveBeenCalledWith(sessionUserConfigPathDummy, {
+        recursive: true,
+        force: true,
+      });
+    });
+
+    it("should create the session user config directory", () => {
+      expect(mkdirSync).toHaveBeenCalledWith(sessionUserConfigPathDummy, {
+        recursive: true,
+      });
+    });
+
+    it("should read the Guidepup user config entries", () => {
+      expect(readdirSync).toHaveBeenCalledWith(guidepupUserConfigPathDummy, {
+        encoding: "utf-8",
+      });
+    });
+
+    it("should copy each Guidepup user config entry to the session user config", () => {
+      expect(cpSync).toHaveBeenNthCalledWith(
+        1,
+        "test-guidepup-user-config/config",
+        "test-session-user-config/config",
+        {
+          recursive: true,
+        },
+      );
+
+      expect(cpSync).toHaveBeenNthCalledWith(
+        2,
+        "test-guidepup-user-config/state.ini",
+        "test-session-user-config/state.ini",
+        {
+          recursive: true,
+        },
+      );
+    });
+  });
+
+  describe("when removing the existing session user config fails", () => {
+    beforeEach(() => {
+      jest.mocked(rmSync).mockImplementation(() => {
+        throw errorDummy;
+      });
+
+      createGuidepupConfig();
+    });
+
+    it("should continue creating the session user config", () => {
+      expect(mkdirSync).toHaveBeenCalledWith(sessionUserConfigPathDummy, {
+        recursive: true,
+      });
+    });
+  });
+
+  describe("when creating the session user config fails", () => {
+    beforeEach(() => {
+      jest.mocked(mkdirSync).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => createGuidepupConfig()).toThrow(
+        new Error(ERR_NVDA_FAILED_TO_CREATE_GUIDEPUP_PREFERENCES, {
+          cause: errorDummy,
+        }),
+      );
+    });
+
+    it("should remove the session user config", () => {
+      try {
+        createGuidepupConfig();
+      } catch {
+        // Swallow
+      }
+
+      expect(rmSync).toHaveBeenLastCalledWith(sessionUserConfigPathDummy, {
+        recursive: true,
+        force: true,
+      });
+    });
+  });
+
+  describe("when reading the Guidepup user config fails", () => {
+    beforeEach(() => {
+      jest.mocked(readdirSync).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => createGuidepupConfig()).toThrow(
+        new Error(ERR_NVDA_FAILED_TO_CREATE_GUIDEPUP_PREFERENCES, {
+          cause: errorDummy,
+        }),
+      );
+    });
+  });
+
+  describe("when copying the Guidepup user config fails", () => {
+    beforeEach(() => {
+      jest.mocked(cpSync).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => createGuidepupConfig()).toThrow(
+        new Error(ERR_NVDA_FAILED_TO_CREATE_GUIDEPUP_PREFERENCES, {
+          cause: errorDummy,
+        }),
+      );
+    });
+
+    it("should remove the session user config", () => {
+      try {
+        createGuidepupConfig();
+      } catch {
+        // Swallow
+      }
+
+      expect(rmSync).toHaveBeenLastCalledWith(sessionUserConfigPathDummy, {
+        recursive: true,
+        force: true,
+      });
+    });
+  });
+});

--- a/src/windows/NVDA/config/createGuidepupConfig.ts
+++ b/src/windows/NVDA/config/createGuidepupConfig.ts
@@ -1,0 +1,50 @@
+import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import {
+  ERR_NVDA_FAILED_TO_CREATE_GUIDEPUP_PREFERENCES,
+  ERR_NVDA_NOT_INSTALLED,
+} from "../../errors";
+import { join } from "node:path";
+import { resolveGuidepupUserConfigPath } from "./resolveGuidepupUserConfigPath";
+import { resolveSessionUserConfigPath } from "./resolveSessionUserConfigPath";
+
+export const createGuidepupConfig = () => {
+  const guidepupUserConfig = resolveGuidepupUserConfigPath();
+
+  if (!existsSync(guidepupUserConfig)) {
+    throw new Error(ERR_NVDA_NOT_INSTALLED);
+  }
+
+  const sessionUserConfigPath = resolveSessionUserConfigPath();
+
+  try {
+    rmSync(sessionUserConfigPath, {
+      recursive: true,
+      force: true,
+    });
+  } catch {
+    // Swallow
+  }
+
+  try {
+    mkdirSync(sessionUserConfigPath, {
+      recursive: true,
+    });
+
+    cpSync(join(guidepupUserConfig, "."), sessionUserConfigPath, {
+      recursive: true,
+    });
+  } catch (error) {
+    try {
+      rmSync(sessionUserConfigPath, {
+        recursive: true,
+        force: true,
+      });
+    } catch {
+      // Swallow
+    }
+
+    throw new Error(ERR_NVDA_FAILED_TO_CREATE_GUIDEPUP_PREFERENCES, {
+      cause: error,
+    });
+  }
+};

--- a/src/windows/NVDA/config/createGuidepupConfig.ts
+++ b/src/windows/NVDA/config/createGuidepupConfig.ts
@@ -16,6 +16,8 @@ export const createGuidepupConfig = () => {
 
   const sessionUserConfigPath = resolveSessionUserConfigPath();
 
+  console.log({ guidepupUserConfigPath, sessionUserConfigPath });
+
   try {
     rmSync(sessionUserConfigPath, {
       recursive: true,
@@ -34,6 +36,8 @@ export const createGuidepupConfig = () => {
       encoding: "utf-8",
     });
 
+    console.log({ entries });
+
     for (const entry of entries) {
       cpSync(
         join(guidepupUserConfigPath, entry),
@@ -43,6 +47,12 @@ export const createGuidepupConfig = () => {
         },
       );
     }
+
+    console.log({
+      dest: readdirSync(sessionUserConfigPath, {
+        encoding: "utf-8",
+      }),
+    });
   } catch (error) {
     try {
       rmSync(sessionUserConfigPath, {

--- a/src/windows/NVDA/config/createGuidepupConfig.ts
+++ b/src/windows/NVDA/config/createGuidepupConfig.ts
@@ -8,13 +8,17 @@ import { resolveGuidepupUserConfigPath } from "./resolveGuidepupUserConfigPath";
 import { resolveSessionUserConfigPath } from "./resolveSessionUserConfigPath";
 
 export const createGuidepupConfig = () => {
-  const guidepupUserConfig = resolveGuidepupUserConfigPath();
+  const guidepupUserConfigPath = resolveGuidepupUserConfigPath();
 
-  if (!existsSync(guidepupUserConfig)) {
+  console.log({ guidepupUserConfigPath });
+
+  if (!existsSync(guidepupUserConfigPath)) {
     throw new Error(ERR_NVDA_NOT_INSTALLED);
   }
 
   const sessionUserConfigPath = resolveSessionUserConfigPath();
+
+  console.log({ sessionUserConfigPath });
 
   try {
     rmSync(sessionUserConfigPath, {
@@ -30,11 +34,16 @@ export const createGuidepupConfig = () => {
       recursive: true,
     });
 
-    for (const entry of readdirSync(guidepupUserConfig, {
+    for (const entry of readdirSync(guidepupUserConfigPath, {
       encoding: "utf-8",
     })) {
+      console.log({
+        from: join(guidepupUserConfigPath, entry),
+        to: join(sessionUserConfigPath, entry),
+      });
+
       cpSync(
-        join(guidepupUserConfig, entry),
+        join(guidepupUserConfigPath, entry),
         join(sessionUserConfigPath, entry),
         {
           recursive: true,

--- a/src/windows/NVDA/config/createGuidepupConfig.ts
+++ b/src/windows/NVDA/config/createGuidepupConfig.ts
@@ -10,7 +10,7 @@ import { resolveSessionUserConfigPath } from "./resolveSessionUserConfigPath";
 export const createGuidepupConfig = () => {
   const guidepupUserConfigPath = resolveGuidepupUserConfigPath();
 
-  console.log({ guidepupUserConfigPath });
+  { guidepupUserConfigPath });
 
   if (!existsSync(guidepupUserConfigPath)) {
     throw new Error(ERR_NVDA_NOT_INSTALLED);
@@ -18,7 +18,7 @@ export const createGuidepupConfig = () => {
 
   const sessionUserConfigPath = resolveSessionUserConfigPath();
 
-  console.log({ sessionUserConfigPath });
+  { sessionUserConfigPath });
 
   try {
     rmSync(sessionUserConfigPath, {
@@ -37,7 +37,7 @@ export const createGuidepupConfig = () => {
     for (const entry of readdirSync(guidepupUserConfigPath, {
       encoding: "utf-8",
     })) {
-      console.log({
+      {
         from: join(guidepupUserConfigPath, entry),
         to: join(sessionUserConfigPath, entry),
       });

--- a/src/windows/NVDA/config/createGuidepupConfig.ts
+++ b/src/windows/NVDA/config/createGuidepupConfig.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import {
   ERR_NVDA_FAILED_TO_CREATE_GUIDEPUP_PREFERENCES,
   ERR_NVDA_NOT_INSTALLED,
@@ -30,9 +30,17 @@ export const createGuidepupConfig = () => {
       recursive: true,
     });
 
-    cpSync(join(guidepupUserConfig, "."), sessionUserConfigPath, {
-      recursive: true,
-    });
+    for (const entry of readdirSync(guidepupUserConfig, {
+      encoding: "utf-8",
+    })) {
+      cpSync(
+        join(guidepupUserConfig, entry),
+        join(sessionUserConfigPath, entry),
+        {
+          recursive: true,
+        },
+      );
+    }
   } catch (error) {
     try {
       rmSync(sessionUserConfigPath, {

--- a/src/windows/NVDA/config/createGuidepupConfig.ts
+++ b/src/windows/NVDA/config/createGuidepupConfig.ts
@@ -16,8 +16,6 @@ export const createGuidepupConfig = () => {
 
   const sessionUserConfigPath = resolveSessionUserConfigPath();
 
-  console.log({ guidepupUserConfigPath, sessionUserConfigPath });
-
   try {
     rmSync(sessionUserConfigPath, {
       recursive: true,
@@ -36,8 +34,6 @@ export const createGuidepupConfig = () => {
       encoding: "utf-8",
     });
 
-    console.log({ entries });
-
     for (const entry of entries) {
       cpSync(
         join(guidepupUserConfigPath, entry),
@@ -47,12 +43,6 @@ export const createGuidepupConfig = () => {
         },
       );
     }
-
-    console.log({
-      dest: readdirSync(sessionUserConfigPath, {
-        encoding: "utf-8",
-      }),
-    });
   } catch (error) {
     try {
       rmSync(sessionUserConfigPath, {

--- a/src/windows/NVDA/config/createGuidepupConfig.ts
+++ b/src/windows/NVDA/config/createGuidepupConfig.ts
@@ -10,15 +10,11 @@ import { resolveSessionUserConfigPath } from "./resolveSessionUserConfigPath";
 export const createGuidepupConfig = () => {
   const guidepupUserConfigPath = resolveGuidepupUserConfigPath();
 
-  { guidepupUserConfigPath });
-
   if (!existsSync(guidepupUserConfigPath)) {
     throw new Error(ERR_NVDA_NOT_INSTALLED);
   }
 
   const sessionUserConfigPath = resolveSessionUserConfigPath();
-
-  { sessionUserConfigPath });
 
   try {
     rmSync(sessionUserConfigPath, {
@@ -34,14 +30,11 @@ export const createGuidepupConfig = () => {
       recursive: true,
     });
 
-    for (const entry of readdirSync(guidepupUserConfigPath, {
+    const entries = readdirSync(guidepupUserConfigPath, {
       encoding: "utf-8",
-    })) {
-      {
-        from: join(guidepupUserConfigPath, entry),
-        to: join(sessionUserConfigPath, entry),
-      });
+    });
 
+    for (const entry of entries) {
       cpSync(
         join(guidepupUserConfigPath, entry),
         join(sessionUserConfigPath, entry),

--- a/src/windows/NVDA/config/deleteGuidepupConfig.test.ts
+++ b/src/windows/NVDA/config/deleteGuidepupConfig.test.ts
@@ -1,0 +1,55 @@
+import { deleteGuidepupConfig } from "./deleteGuidepupConfig";
+import { resolveSessionUserConfigPath } from "./resolveSessionUserConfigPath";
+import { rmSync } from "node:fs";
+
+jest.mock("node:fs", () => ({
+  rmSync: jest.fn(),
+}));
+
+jest.mock("./resolveSessionUserConfigPath", () => ({
+  resolveSessionUserConfigPath: jest.fn(),
+}));
+
+const sessionUserConfigPathDummy = "test-session-user-config";
+
+describe("deleteGuidepupConfig", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest
+      .mocked(resolveSessionUserConfigPath)
+      .mockReturnValue(sessionUserConfigPathDummy);
+  });
+
+  it("should resolve the session user config path", () => {
+    deleteGuidepupConfig();
+
+    expect(resolveSessionUserConfigPath).toHaveBeenCalled();
+  });
+
+  it("should remove the session user config", () => {
+    deleteGuidepupConfig();
+
+    expect(rmSync).toHaveBeenCalledWith(sessionUserConfigPathDummy, {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  describe("when removing the session user config fails", () => {
+    beforeEach(() => {
+      jest.mocked(rmSync).mockImplementation(() => {
+        throw new Error("test-error");
+      });
+    });
+
+    it("should swallow the error", () => {
+      deleteGuidepupConfig();
+
+      expect(rmSync).toHaveBeenCalledWith(sessionUserConfigPathDummy, {
+        recursive: true,
+        force: true,
+      });
+    });
+  });
+});

--- a/src/windows/NVDA/config/deleteGuidepupConfig.ts
+++ b/src/windows/NVDA/config/deleteGuidepupConfig.ts
@@ -1,0 +1,15 @@
+import { resolveSessionUserConfigPath } from "./resolveSessionUserConfigPath";
+import { rmSync } from "node:fs";
+
+export const deleteGuidepupConfig = () => {
+  const sessionUserConfigPath = resolveSessionUserConfigPath();
+
+  try {
+    rmSync(sessionUserConfigPath, {
+      recursive: true,
+      force: true,
+    });
+  } catch {
+    // Swallow
+  }
+};

--- a/src/windows/NVDA/config/getConfig.test.ts
+++ b/src/windows/NVDA/config/getConfig.test.ts
@@ -1,0 +1,130 @@
+import { existsSync, readFileSync } from "node:fs";
+import { ERR_NVDA_FAILED_TO_GET_SETTINGS } from "../../errors";
+import { getConfig } from "./getConfig";
+import { parseIni } from "./parseIni";
+import { resolveGuidepupUserConfigPath } from "./resolveGuidepupUserConfigPath";
+import { resolveSessionUserConfigPath } from "./resolveSessionUserConfigPath";
+
+jest.mock("node:fs", () => ({
+  existsSync: jest.fn(),
+  readFileSync: jest.fn(),
+}));
+
+jest.mock("./parseIni", () => ({
+  parseIni: jest.fn(),
+}));
+
+jest.mock("./resolveGuidepupUserConfigPath", () => ({
+  resolveGuidepupUserConfigPath: jest.fn(),
+}));
+
+jest.mock("./resolveSessionUserConfigPath", () => ({
+  resolveSessionUserConfigPath: jest.fn(),
+}));
+
+const sessionUserConfigPathDummy = "test-session-user-config";
+const guidepupUserConfigPathDummy = "test-guidepup-user-config";
+
+const sessionConfigPathDummy = "test-session-user-config/nvda.ini";
+const guidepupConfigPathDummy = "test-guidepup-user-config/nvda.ini";
+
+const contentsDummy = "test-config";
+const configDummy = {
+  testSetting: "test-value",
+};
+
+const errorDummy = new Error("test-error");
+
+describe("getConfig", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest
+      .mocked(resolveSessionUserConfigPath)
+      .mockReturnValue(sessionUserConfigPathDummy);
+
+    jest
+      .mocked(resolveGuidepupUserConfigPath)
+      .mockReturnValue(guidepupUserConfigPathDummy);
+
+    jest.mocked(readFileSync).mockReturnValue(contentsDummy);
+    jest.mocked(parseIni).mockReturnValue(configDummy);
+  });
+
+  describe("when the session user config exists", () => {
+    beforeEach(() => {
+      jest.mocked(existsSync).mockReturnValue(true);
+    });
+
+    it("should check whether the session user config exists", () => {
+      getConfig();
+
+      expect(existsSync).toHaveBeenCalledWith(sessionConfigPathDummy);
+    });
+
+    it("should read the session user config", () => {
+      getConfig();
+
+      expect(readFileSync).toHaveBeenCalledWith(sessionConfigPathDummy, "utf8");
+    });
+
+    it("should parse the config", () => {
+      getConfig();
+
+      expect(parseIni).toHaveBeenCalledWith(contentsDummy);
+    });
+  });
+
+  describe("when the session user config does not exist", () => {
+    beforeEach(() => {
+      jest.mocked(existsSync).mockReturnValue(false);
+    });
+
+    it("should read the Guidepup user config", () => {
+      getConfig();
+
+      expect(readFileSync).toHaveBeenCalledWith(
+        guidepupConfigPathDummy,
+        "utf8",
+      );
+    });
+
+    it("should parse the config", () => {
+      getConfig();
+
+      expect(parseIni).toHaveBeenCalledWith(contentsDummy);
+    });
+  });
+
+  describe("when reading the config fails", () => {
+    beforeEach(() => {
+      jest.mocked(readFileSync).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => getConfig()).toThrow(
+        new Error(ERR_NVDA_FAILED_TO_GET_SETTINGS, {
+          cause: errorDummy,
+        }),
+      );
+    });
+  });
+
+  describe("when parsing the config fails", () => {
+    beforeEach(() => {
+      jest.mocked(parseIni).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => getConfig()).toThrow(
+        new Error(ERR_NVDA_FAILED_TO_GET_SETTINGS, {
+          cause: errorDummy,
+        }),
+      );
+    });
+  });
+});

--- a/src/windows/NVDA/config/getConfig.ts
+++ b/src/windows/NVDA/config/getConfig.ts
@@ -1,3 +1,27 @@
+import { existsSync, readFileSync } from "node:fs";
+import { ERR_NVDA_FAILED_TO_GET_SETTINGS } from "../../errors";
+import { join } from "node:path";
+import { parseIni } from "./parseIni";
+import { resolveGuidepupUserConfigPath } from "./resolveGuidepupUserConfigPath";
+import { resolveSessionUserConfigPath } from "./resolveSessionUserConfigPath";
+
 export function getConfig(): Record<string, unknown> {
-  return {};
+  const sessionUserConfigPath = join(
+    resolveSessionUserConfigPath(),
+    "nvda.ini",
+  );
+
+  const configPath = existsSync(sessionUserConfigPath)
+    ? sessionUserConfigPath
+    : join(resolveGuidepupUserConfigPath(), "nvda.ini");
+
+  try {
+    const contents = readFileSync(configPath, "utf8");
+
+    return parseIni(contents);
+  } catch (cause) {
+    throw new Error(ERR_NVDA_FAILED_TO_GET_SETTINGS, {
+      cause,
+    });
+  }
 }

--- a/src/windows/NVDA/config/getConfig.ts
+++ b/src/windows/NVDA/config/getConfig.ts
@@ -1,0 +1,3 @@
+export function getConfig(): Record<string, unknown> {
+  return {};
+}

--- a/src/windows/NVDA/config/getConfigKey.test.ts
+++ b/src/windows/NVDA/config/getConfigKey.test.ts
@@ -1,0 +1,49 @@
+import { getConfig } from "./getConfig";
+import { getConfigKey } from "./getConfigKey";
+
+jest.mock("./getConfig", () => ({
+  getConfig: jest.fn(),
+}));
+
+const keyDummy = "test-key";
+const valueDummy = "test-value";
+
+describe("getConfigKey", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when the config exists", () => {
+    beforeEach(() => {
+      jest.mocked(getConfig).mockReturnValue({
+        [keyDummy]: valueDummy,
+      });
+    });
+
+    it("should return the config value", () => {
+      expect(getConfigKey(keyDummy)).toBe(valueDummy);
+    });
+
+    it("should get config", () => {
+      getConfigKey(keyDummy);
+
+      expect(getConfig).toHaveBeenCalled();
+    });
+  });
+
+  describe("when the config does not exist", () => {
+    beforeEach(() => {
+      jest.mocked(getConfig).mockReturnValue({});
+    });
+
+    it("should return undefined", () => {
+      expect(getConfigKey(keyDummy)).toBeUndefined();
+    });
+
+    it("should get config", () => {
+      getConfigKey(keyDummy);
+
+      expect(getConfig).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/windows/NVDA/config/getConfigKey.ts
+++ b/src/windows/NVDA/config/getConfigKey.ts
@@ -1,0 +1,7 @@
+import { getConfig } from "./getConfig";
+
+export function getConfigKey(key: string): unknown {
+  const config = getConfig();
+
+  return config[key];
+}

--- a/src/windows/NVDA/config/index.ts
+++ b/src/windows/NVDA/config/index.ts
@@ -1,0 +1,6 @@
+export { createGuidepupConfig } from "./createGuidepupConfig";
+export { deleteGuidepupConfig } from "./deleteGuidepupConfig";
+export { getConfig } from "./getConfig";
+export { getConfigKey } from "./getConfigKey";
+export { resolveSessionUserConfigPath } from "./resolveSessionUserConfigPath";
+export { setConfig } from "./setConfig";

--- a/src/windows/NVDA/config/parseIni.test.ts
+++ b/src/windows/NVDA/config/parseIni.test.ts
@@ -54,87 +54,91 @@ const missingSeparatorResult = {
 
 const realWorldInput = `schemaVersion = 22
 [math]
-	[[speech]]
-		impairment = Blindness
-		language = en
-		verbosity = Medium
-		mathRate = 100
-		pauseFactor = 100
-		speechSound = None
-		chemistry = SpellOut
-		[[[en]]]
-			speechStyle = ClearSpeak
-	[[speech.speechOverrides]]
-	[[speech.ClearSpeak]]
-	[[navigation]]
-		navMode = Enhanced
-		resetNavMode = True
-		overview = False
-		resetOverview = True
-		navVerbosity = Medium
-		autoZoomOut = True
-		copyAs = MathML
-	[[braille]]
-		brailleCode = Auto
-		brailleNavHighlight = EndPoints
-	[[braille.nemeth]]
-	[[braille.UEB]]
-	[[braille.vietnam]]
-	[[braille.LaTeX]]
-	[[other]]
-		decimalSeparator = Auto
-		useWordNativeMath = False
-	[[ui]]
-		confirmDisconnectAsFollower = False
-		muteOnLocalControl = False
+\t[[speech]]
+\t\timpairment = Blindness
+\t\tlanguage = en
+\t\tverbosity = Medium
+\t\tmathRate = 100
+\t\tpauseFactor = 100
+\t\tspeechSound = None
+\t\tchemistry = SpellOut
+\t\t[[[en]]]
+\t\t\tspeechStyle = ClearSpeak
+\t[[speech.speechOverrides]]
+\t[[speech.ClearSpeak]]
+\t[[navigation]]
+\t\tnavMode = Enhanced
+\t\tresetNavMode = True
+\t\toverview = False
+\t\tresetOverview = True
+\t\tnavVerbosity = Medium
+\t\tautoZoomOut = True
+\t\tcopyAs = MathML
+\t[[braille]]
+\t\tbrailleCode = Auto
+\t\tbrailleNavHighlight = EndPoints
+\t[[braille.nemeth]]
+\t[[braille.UEB]]
+\t[[braille.vietnam]]
+\t[[braille.LaTeX]]
+\t[[other]]
+\t\tdecimalSeparator = Auto
+\t\tuseWordNativeMath = False
+\t[[ui]]
+\t\tconfirmDisconnectAsFollower = False
+\t\tmuteOnLocalControl = False
+[remote]
+\tenabled = True
+\t[[connections]]
+\t\tlastConnected = 127.0.0.1:6837,
 [development]
 [screenCurtain]
-	warnOnLoad = True
-	playToggleSounds = True
+\twarnOnLoad = True
+\tplayToggleSounds = True
 [update]
-	allowUsageStats = False
-	askedAllowUsageStats = True
-	autoCheck = False
-	startupNotification = False
+\tallowUsageStats = False
+\taskedAllowUsageStats = True
+\tautoCheck = False
+\tstartupNotification = False
 [addonStore]
-	automaticUpdates = disabled
-	allowIncompatibleUpdates = False
-	defaultUpdateChannel = 2
+\tautomaticUpdates = disabled
+\tallowIncompatibleUpdates = False
+\tdefaultUpdateChannel = 2
 [general]
-	showWelcomeDialogAtStartup = False
-	language = Windows
-	saveConfigurationOnExit = False
-	askToExit = False
-	playStartAndExitSounds = False
-	loggingLevel = OFF
-	preventDisplayTurningOff = True
+\tshowWelcomeDialogAtStartup = False
+\tlanguage = Windows
+\tsaveConfigurationOnExit = False
+\taskToExit = False
+\tplayStartAndExitSounds = False
+\tloggingLevel = OFF
+\tpreventDisplayTurningOff = True
 [speech]
-	synth = oneCore
-	[[oneCore]]
-		voice = HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Speech_OneCore\\Voices\\Tokens\\MSTTS_V110_enGB_GeorgeM
-		volume = 100
-		rate = 100
-		rateBoost = True
+\tsynth = oneCore
+\t[[oneCore]]
+\t\tvoice = HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Speech_OneCore\\Voices\\Tokens\\MSTTS_V110_enGB_GeorgeM
+\t\tvolume = 100
+\t\trate = 100
+\t\trateBoost = True
 [braille]
-	[[noBraille]]
+\t[[noBraille]]
 [vision]
-	[[NVDAHighlighter]]
-		highlightFocus = True
-		highlightNavigator = True
-		highlightBrowseMode = True
-		enabled = True
+\t[[NVDAHighlighter]]
+\t\thighlightFocus = True
+\t\thighlightNavigator = True
+\t\thighlightBrowseMode = True
+\t\tenabled = True
 [speechViewer]
-	x = 0
-	y = 0
-	width = 500
-	height = 500
-	displays = "(1920, 1080)",
-	autoPositionWindow = True
-	showSpeechViewerAtStartup = True
+\tx = 0
+\ty = 0
+\twidth = 500
+\theight = 500
+\tdisplays = "(1920, 1080)",
+\tautoPositionWindow = True
+\tshowSpeechViewerAtStartup = True
 [virtualBuffers]
-	autoSayAllOnPageLoad = False
+\tautoSayAllOnPageLoad = False
 [uwpOcr]
-	language = en-GB`;
+\tlanguage = en-GB`;
 
 const realWorldResult = {
   addonStore: {
@@ -196,6 +200,12 @@ const realWorldResult = {
       muteOnLocalControl: false,
     },
   },
+  remote: {
+    connections: {
+      lastConnected: ["127.0.0.1:6837"],
+    },
+    enabled: true,
+  },
   schemaVersion: 22,
   screenCurtain: {
     playToggleSounds: true,
@@ -213,7 +223,7 @@ const realWorldResult = {
   },
   speechViewer: {
     autoPositionWindow: true,
-    displays: '"(1920, 1080)",',
+    displays: ["(1920, 1080)"],
     height: 500,
     showSpeechViewerAtStartup: true,
     width: 500,

--- a/src/windows/NVDA/config/parseIni.test.ts
+++ b/src/windows/NVDA/config/parseIni.test.ts
@@ -1,0 +1,260 @@
+import { parseIni } from "./parseIni";
+
+const topLevelPrimitivesInput = `a = string
+b = 123
+c = True
+d = "quoted string"`;
+
+const topLevelPrimitivesResult = {
+  a: "string",
+  b: 123,
+  c: true,
+  d: "quoted string",
+};
+
+const nestedKeysInput = `a = "top level key"
+[b]
+\tc = "nested key"
+\t[[d]]
+\t\te = "double nested key"
+\t\t[[[f]]]
+\t\t\tg = "triple nested key"
+\t\t[[[h]]]
+\t\t\ti = "another triple nested key"
+[j]
+\tk = "another nested key"`;
+
+const nestedKeysResult = {
+  a: "top level key",
+  b: {
+    c: "nested key",
+    d: {
+      e: "double nested key",
+      f: {
+        g: "triple nested key",
+      },
+      h: {
+        i: "another triple nested key",
+      },
+    },
+  },
+  j: {
+    k: "another nested key",
+  },
+};
+
+const missingSeparatorInput = `a = "first value"
+invalid line
+b = "second value"`;
+
+const missingSeparatorResult = {
+  a: "first value",
+  b: "second value",
+};
+
+const realWorldInput = `schemaVersion = 22
+[math]
+	[[speech]]
+		impairment = Blindness
+		language = en
+		verbosity = Medium
+		mathRate = 100
+		pauseFactor = 100
+		speechSound = None
+		chemistry = SpellOut
+		[[[en]]]
+			speechStyle = ClearSpeak
+	[[speech.speechOverrides]]
+	[[speech.ClearSpeak]]
+	[[navigation]]
+		navMode = Enhanced
+		resetNavMode = True
+		overview = False
+		resetOverview = True
+		navVerbosity = Medium
+		autoZoomOut = True
+		copyAs = MathML
+	[[braille]]
+		brailleCode = Auto
+		brailleNavHighlight = EndPoints
+	[[braille.nemeth]]
+	[[braille.UEB]]
+	[[braille.vietnam]]
+	[[braille.LaTeX]]
+	[[other]]
+		decimalSeparator = Auto
+		useWordNativeMath = False
+	[[ui]]
+		confirmDisconnectAsFollower = False
+		muteOnLocalControl = False
+[development]
+[screenCurtain]
+	warnOnLoad = True
+	playToggleSounds = True
+[update]
+	allowUsageStats = False
+	askedAllowUsageStats = True
+	autoCheck = False
+	startupNotification = False
+[addonStore]
+	automaticUpdates = disabled
+	allowIncompatibleUpdates = False
+	defaultUpdateChannel = 2
+[general]
+	showWelcomeDialogAtStartup = False
+	language = Windows
+	saveConfigurationOnExit = False
+	askToExit = False
+	playStartAndExitSounds = False
+	loggingLevel = OFF
+	preventDisplayTurningOff = True
+[speech]
+	synth = oneCore
+	[[oneCore]]
+		voice = HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Speech_OneCore\\Voices\\Tokens\\MSTTS_V110_enGB_GeorgeM
+		volume = 100
+		rate = 100
+		rateBoost = True
+[braille]
+	[[noBraille]]
+[vision]
+	[[NVDAHighlighter]]
+		highlightFocus = True
+		highlightNavigator = True
+		highlightBrowseMode = True
+		enabled = True
+[speechViewer]
+	x = 0
+	y = 0
+	width = 500
+	height = 500
+	displays = "(1920, 1080)",
+	autoPositionWindow = True
+	showSpeechViewerAtStartup = True
+[virtualBuffers]
+	autoSayAllOnPageLoad = False
+[uwpOcr]
+	language = en-GB`;
+
+const realWorldResult = {
+  addonStore: {
+    allowIncompatibleUpdates: false,
+    automaticUpdates: "disabled",
+    defaultUpdateChannel: 2,
+  },
+  braille: {
+    noBraille: {},
+  },
+  development: {},
+  general: {
+    askToExit: false,
+    language: "Windows",
+    loggingLevel: "OFF",
+    playStartAndExitSounds: false,
+    preventDisplayTurningOff: true,
+    saveConfigurationOnExit: false,
+    showWelcomeDialogAtStartup: false,
+  },
+  math: {
+    braille: {
+      brailleCode: "Auto",
+      brailleNavHighlight: "EndPoints",
+    },
+    "braille.LaTeX": {},
+    "braille.UEB": {},
+    "braille.nemeth": {},
+    "braille.vietnam": {},
+    navigation: {
+      autoZoomOut: true,
+      copyAs: "MathML",
+      navMode: "Enhanced",
+      navVerbosity: "Medium",
+      overview: false,
+      resetNavMode: true,
+      resetOverview: true,
+    },
+    other: {
+      decimalSeparator: "Auto",
+      useWordNativeMath: false,
+    },
+    speech: {
+      chemistry: "SpellOut",
+      en: {
+        speechStyle: "ClearSpeak",
+      },
+      impairment: "Blindness",
+      language: "en",
+      mathRate: 100,
+      pauseFactor: 100,
+      speechSound: "None",
+      verbosity: "Medium",
+    },
+    "speech.ClearSpeak": {},
+    "speech.speechOverrides": {},
+    ui: {
+      confirmDisconnectAsFollower: false,
+      muteOnLocalControl: false,
+    },
+  },
+  schemaVersion: 22,
+  screenCurtain: {
+    playToggleSounds: true,
+    warnOnLoad: true,
+  },
+  speech: {
+    oneCore: {
+      rate: 100,
+      rateBoost: true,
+      voice:
+        "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Speech_OneCore\\Voices\\Tokens\\MSTTS_V110_enGB_GeorgeM",
+      volume: 100,
+    },
+    synth: "oneCore",
+  },
+  speechViewer: {
+    autoPositionWindow: true,
+    displays: '"(1920, 1080)",',
+    height: 500,
+    showSpeechViewerAtStartup: true,
+    width: 500,
+    x: 0,
+    y: 0,
+  },
+  update: {
+    allowUsageStats: false,
+    askedAllowUsageStats: true,
+    autoCheck: false,
+    startupNotification: false,
+  },
+  uwpOcr: {
+    language: "en-GB",
+  },
+  virtualBuffers: {
+    autoSayAllOnPageLoad: false,
+  },
+  vision: {
+    NVDAHighlighter: {
+      enabled: true,
+      highlightBrowseMode: true,
+      highlightFocus: true,
+      highlightNavigator: true,
+    },
+  },
+};
+
+describe("parseIni", () => {
+  it.each`
+    description                               | input                           | expectedResult
+    ${"empty"}                                | ${""}                           | ${{}}
+    ${"comments"}                             | ${"# comment\na = string"}      | ${{ a: "string" }}
+    ${"repeated"}                             | ${"a = string\na = 123"}        | ${{ a: 123 }}
+    ${"repeated as section"}                  | ${"a = string\n[a]\n\tb = 123"} | ${{ a: { b: 123 } }}
+    ${"separator in string"}                  | ${"a = ==="}                    | ${{ a: "===" }}
+    ${"top level keys with primitive values"} | ${topLevelPrimitivesInput}      | ${topLevelPrimitivesResult}
+    ${"nested keys"}                          | ${nestedKeysInput}              | ${nestedKeysResult}
+    ${"missing separator"}                    | ${missingSeparatorInput}        | ${missingSeparatorResult}
+    ${"real world input"}                     | ${realWorldInput}               | ${realWorldResult}
+  `("$description", ({ input, expectedResult }) => {
+    expect(parseIni(input)).toEqual(expectedResult);
+  });
+});

--- a/src/windows/NVDA/config/parseIni.test.ts
+++ b/src/windows/NVDA/config/parseIni.test.ts
@@ -263,6 +263,9 @@ describe("parseIni", () => {
     ${"top level keys with primitive values"} | ${topLevelPrimitivesInput}      | ${topLevelPrimitivesResult}
     ${"nested keys"}                          | ${nestedKeysInput}              | ${nestedKeysResult}
     ${"missing separator"}                    | ${missingSeparatorInput}        | ${missingSeparatorResult}
+    ${"empty array"}                          | ${`a = ,`}                      | ${{ a: [] }}
+    ${"array with empty item"}                | ${`a = one,,two,`}              | ${{ a: ["one", "two"] }}
+    ${"array with quoted items"}              | ${`a = "one, still one",two,`}  | ${{ a: ["one, still one", "two"] }}
     ${"real world input"}                     | ${realWorldInput}               | ${realWorldResult}
   `("$description", ({ input, expectedResult }) => {
     expect(parseIni(input)).toEqual(expectedResult);

--- a/src/windows/NVDA/config/parseIni.ts
+++ b/src/windows/NVDA/config/parseIni.ts
@@ -1,3 +1,30 @@
+function splitArray(value: string): string[] {
+  const result: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (const char of value) {
+    if (char === '"') {
+      inQuotes = !inQuotes;
+    }
+
+    if (char === "," && !inQuotes) {
+      if (current) {
+        result.push(current.trim());
+        current = "";
+      }
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    result.push(current.trim());
+  }
+
+  return result;
+}
+
 function parseValue(value: string): unknown {
   if (value === "True") {
     return true;
@@ -13,7 +40,13 @@ function parseValue(value: string): unknown {
     return number;
   }
 
-  return value.replace(/^"(.*)"$/, "$1");
+  if (value.endsWith(",")) {
+    return splitArray(value.slice(0, -1)).map((item) =>
+      item.replace(/^"(.*)"$/, "$1").replace(/\\"/g, '"'),
+    );
+  }
+
+  return value.replace(/^"(.*)"$/, "$1").replace(/\\"/g, '"');
 }
 
 export function parseIni(contents: string): Record<string, unknown> {

--- a/src/windows/NVDA/config/parseIni.ts
+++ b/src/windows/NVDA/config/parseIni.ts
@@ -1,0 +1,63 @@
+function parseValue(value: string): unknown {
+  if (value === "True") {
+    return true;
+  }
+
+  if (value === "False") {
+    return false;
+  }
+
+  const number = Number(value);
+
+  if (!Number.isNaN(number)) {
+    return number;
+  }
+
+  return value.replace(/^"(.*)"$/, "$1");
+}
+
+export function parseIni(contents: string): Record<string, unknown> {
+  const config: Record<string, unknown> = {};
+
+  const sections: Record<number, Record<string, unknown>> = {
+    0: config,
+  };
+
+  let depth = 0;
+
+  for (const line of contents.split(/\r?\n/)) {
+    const trimmed = line.trim();
+
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const sectionMatch = trimmed.match(/^(\[+)(.+?)(\]+)$/);
+
+    if (sectionMatch) {
+      depth = sectionMatch[1].length;
+
+      const name = sectionMatch[2].trim();
+      const parent = sections[depth - 1];
+      const section: Record<string, unknown> = {};
+
+      parent[name] = section;
+      sections[depth] = section;
+
+      continue;
+    }
+
+    const separatorIndex = trimmed.indexOf("=");
+
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    const value = trimmed.slice(separatorIndex + 1).trim();
+
+    sections[depth][key] = parseValue(value);
+  }
+
+  return config;
+}

--- a/src/windows/NVDA/config/resolveGuidepupUserConfigPath.test.ts
+++ b/src/windows/NVDA/config/resolveGuidepupUserConfigPath.test.ts
@@ -1,0 +1,41 @@
+jest.mock("../../../../manifest.json", () => ({
+  screenReaders: [
+    {
+      id: "nvda",
+      assets: [
+        {
+          version: "test-version",
+        },
+      ],
+    },
+  ],
+}));
+
+import { resolveCachePath } from "../../../resolveCachePath";
+import { resolveGuidepupUserConfigPath } from "./resolveGuidepupUserConfigPath";
+
+jest.mock("../../../resolveCachePath", () => ({
+  resolveCachePath: jest.fn(),
+}));
+
+const cachePathDummy = "test-cache-path";
+
+describe("resolveGuidepupUserConfigPath", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(resolveCachePath).mockReturnValue(cachePathDummy);
+  });
+
+  it("should resolve the cache path", () => {
+    resolveGuidepupUserConfigPath();
+
+    expect(resolveCachePath).toHaveBeenCalled();
+  });
+
+  it("should resolve the Guidepup user config path", () => {
+    expect(resolveGuidepupUserConfigPath()).toBe(
+      "test-cache-path/nvda/all/test-version/extracted/userConfig",
+    );
+  });
+});

--- a/src/windows/NVDA/config/resolveGuidepupUserConfigPath.ts
+++ b/src/windows/NVDA/config/resolveGuidepupUserConfigPath.ts
@@ -1,0 +1,21 @@
+import { join } from "node:path";
+import { resolveCachePath } from "../../../resolveCachePath";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const manifest = require("../../../../manifest.json");
+
+export function resolveGuidepupUserConfigPath() {
+  const asset = manifest.screenReaders.find(({ id }) => id === "nvda")
+    .assets[0];
+
+  const cachePath = resolveCachePath();
+
+  return join(
+    cachePath,
+    "nvda",
+    "all",
+    asset.version,
+    "extracted",
+    "userConfig",
+  );
+}

--- a/src/windows/NVDA/config/resolveSessionUserConfigPath.test.ts
+++ b/src/windows/NVDA/config/resolveSessionUserConfigPath.test.ts
@@ -1,0 +1,41 @@
+jest.mock("../../../../manifest.json", () => ({
+  screenReaders: [
+    {
+      id: "nvda",
+      assets: [
+        {
+          version: "test-version",
+        },
+      ],
+    },
+  ],
+}));
+
+import { resolveCachePath } from "../../../resolveCachePath";
+import { resolveSessionUserConfigPath } from "./resolveSessionUserConfigPath";
+
+jest.mock("../../../resolveCachePath", () => ({
+  resolveCachePath: jest.fn(),
+}));
+
+const cachePathDummy = "test-cache-path";
+
+describe("resolveSessionUserConfigPath", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(resolveCachePath).mockReturnValue(cachePathDummy);
+  });
+
+  it("should resolve the cache path", () => {
+    resolveSessionUserConfigPath();
+
+    expect(resolveCachePath).toHaveBeenCalled();
+  });
+
+  it("should resolve the session user config path", () => {
+    expect(resolveSessionUserConfigPath()).toBe(
+      "test-cache-path/nvda/all/test-version/sessionUserConfig",
+    );
+  });
+});

--- a/src/windows/NVDA/config/resolveSessionUserConfigPath.ts
+++ b/src/windows/NVDA/config/resolveSessionUserConfigPath.ts
@@ -1,0 +1,14 @@
+import { join } from "node:path";
+import { resolveCachePath } from "../../../resolveCachePath";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const manifest = require("../../../../manifest.json");
+
+export function resolveSessionUserConfigPath() {
+  const asset = manifest.screenReaders.find(({ id }) => id === "nvda")
+    .assets[0];
+
+  const cachePath = resolveCachePath();
+
+  return join(cachePath, "nvda", "all", asset.version, "sessionUserConfig");
+}

--- a/src/windows/NVDA/config/setConfig.test.ts
+++ b/src/windows/NVDA/config/setConfig.test.ts
@@ -1,4 +1,5 @@
 import { buildIni } from "./buildIni";
+import { deepMerge } from "../../../deepMerge";
 import { ERR_NVDA_FAILED_TO_SET_SETTING } from "../../errors";
 import { getConfig } from "./getConfig";
 import { join } from "node:path";
@@ -8,6 +9,10 @@ import { writeFileSync } from "node:fs";
 
 jest.mock("./buildIni", () => ({
   buildIni: jest.fn(),
+}));
+
+jest.mock("../../../deepMerge", () => ({
+  deepMerge: jest.fn(),
 }));
 
 jest.mock("./getConfig", () => ({
@@ -23,20 +28,20 @@ jest.mock("node:fs", () => ({
 }));
 
 const configDummy = {
-  existingSetting: "existing-value",
+  existing: "config",
 };
 
 const desiredConfigDummy = {
-  desiredSetting: "desired-value",
+  desired: "config",
 };
 
-const updatedConfigDummy = {
-  existingSetting: "existing-value",
-  desiredConfig: desiredConfigDummy,
+const mergedConfigDummy = {
+  merged: "config",
 };
+
+const builtConfigDummy = "built config";
 
 const sessionUserConfigPathDummy = "test-session-user-config";
-const iniConfigDummy = "test-ini-config";
 
 const errorDummy = new Error("test-error");
 
@@ -45,42 +50,59 @@ describe("setConfig", () => {
     jest.clearAllMocks();
 
     jest.mocked(getConfig).mockReturnValue(configDummy);
+    jest.mocked(deepMerge).mockReturnValue(mergedConfigDummy);
     jest
       .mocked(resolveSessionUserConfigPath)
       .mockReturnValue(sessionUserConfigPathDummy);
-    jest.mocked(buildIni).mockReturnValue(iniConfigDummy);
+    jest.mocked(buildIni).mockReturnValue(builtConfigDummy);
   });
 
-  it("should get the current config", () => {
+  it("should get the existing config", () => {
     setConfig(desiredConfigDummy);
 
     expect(getConfig).toHaveBeenCalled();
   });
 
-  it("should build the updated config", () => {
+  it("should merge the desired config with the existing config", () => {
     setConfig(desiredConfigDummy);
 
-    expect(buildIni).toHaveBeenCalledWith(updatedConfigDummy);
+    expect(deepMerge).toHaveBeenCalledWith(configDummy, desiredConfigDummy);
   });
 
-  it("should resolve the session user config path", () => {
+  it("should build the merged config as an ini file", () => {
     setConfig(desiredConfigDummy);
 
-    expect(resolveSessionUserConfigPath).toHaveBeenCalled();
+    expect(buildIni).toHaveBeenCalledWith(mergedConfigDummy);
   });
 
-  it("should write the config file", () => {
+  it("should write the config to the session user config path", () => {
     setConfig(desiredConfigDummy);
 
     expect(writeFileSync).toHaveBeenCalledWith(
       join(sessionUserConfigPathDummy, "nvda.ini"),
-      iniConfigDummy,
+      builtConfigDummy,
     );
   });
 
-  describe("when getting the current config fails", () => {
+  describe("when getting the config fails", () => {
     beforeEach(() => {
       jest.mocked(getConfig).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => setConfig(desiredConfigDummy)).toThrow(
+        new Error(ERR_NVDA_FAILED_TO_SET_SETTING, {
+          cause: errorDummy,
+        }),
+      );
+    });
+  });
+
+  describe("when merging the config fails", () => {
+    beforeEach(() => {
+      jest.mocked(deepMerge).mockImplementation(() => {
         throw errorDummy;
       });
     });
@@ -110,7 +132,7 @@ describe("setConfig", () => {
     });
   });
 
-  describe("when writing the config file fails", () => {
+  describe("when writing the config fails", () => {
     beforeEach(() => {
       jest.mocked(writeFileSync).mockImplementation(() => {
         throw errorDummy;

--- a/src/windows/NVDA/config/setConfig.test.ts
+++ b/src/windows/NVDA/config/setConfig.test.ts
@@ -1,0 +1,128 @@
+import { buildIni } from "./buildIni";
+import { ERR_NVDA_FAILED_TO_SET_SETTING } from "../../errors";
+import { getConfig } from "./getConfig";
+import { join } from "node:path";
+import { resolveSessionUserConfigPath } from "./resolveSessionUserConfigPath";
+import { setConfig } from "./setConfig";
+import { writeFileSync } from "node:fs";
+
+jest.mock("./buildIni", () => ({
+  buildIni: jest.fn(),
+}));
+
+jest.mock("./getConfig", () => ({
+  getConfig: jest.fn(),
+}));
+
+jest.mock("./resolveSessionUserConfigPath", () => ({
+  resolveSessionUserConfigPath: jest.fn(),
+}));
+
+jest.mock("node:fs", () => ({
+  writeFileSync: jest.fn(),
+}));
+
+const configDummy = {
+  existingSetting: "existing-value",
+};
+
+const desiredConfigDummy = {
+  desiredSetting: "desired-value",
+};
+
+const updatedConfigDummy = {
+  existingSetting: "existing-value",
+  desiredConfig: desiredConfigDummy,
+};
+
+const sessionUserConfigPathDummy = "test-session-user-config";
+const iniConfigDummy = "test-ini-config";
+
+const errorDummy = new Error("test-error");
+
+describe("setConfig", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(getConfig).mockReturnValue(configDummy);
+    jest
+      .mocked(resolveSessionUserConfigPath)
+      .mockReturnValue(sessionUserConfigPathDummy);
+    jest.mocked(buildIni).mockReturnValue(iniConfigDummy);
+  });
+
+  it("should get the current config", () => {
+    setConfig(desiredConfigDummy);
+
+    expect(getConfig).toHaveBeenCalled();
+  });
+
+  it("should build the updated config", () => {
+    setConfig(desiredConfigDummy);
+
+    expect(buildIni).toHaveBeenCalledWith(updatedConfigDummy);
+  });
+
+  it("should resolve the session user config path", () => {
+    setConfig(desiredConfigDummy);
+
+    expect(resolveSessionUserConfigPath).toHaveBeenCalled();
+  });
+
+  it("should write the config file", () => {
+    setConfig(desiredConfigDummy);
+
+    expect(writeFileSync).toHaveBeenCalledWith(
+      join(sessionUserConfigPathDummy, "nvda.ini"),
+      iniConfigDummy,
+    );
+  });
+
+  describe("when getting the current config fails", () => {
+    beforeEach(() => {
+      jest.mocked(getConfig).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => setConfig(desiredConfigDummy)).toThrow(
+        new Error(ERR_NVDA_FAILED_TO_SET_SETTING, {
+          cause: errorDummy,
+        }),
+      );
+    });
+  });
+
+  describe("when building the config fails", () => {
+    beforeEach(() => {
+      jest.mocked(buildIni).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => setConfig(desiredConfigDummy)).toThrow(
+        new Error(ERR_NVDA_FAILED_TO_SET_SETTING, {
+          cause: errorDummy,
+        }),
+      );
+    });
+  });
+
+  describe("when writing the config file fails", () => {
+    beforeEach(() => {
+      jest.mocked(writeFileSync).mockImplementation(() => {
+        throw errorDummy;
+      });
+    });
+
+    it("should throw an error with the cause", () => {
+      expect(() => setConfig(desiredConfigDummy)).toThrow(
+        new Error(ERR_NVDA_FAILED_TO_SET_SETTING, {
+          cause: errorDummy,
+        }),
+      );
+    });
+  });
+});

--- a/src/windows/NVDA/config/setConfig.ts
+++ b/src/windows/NVDA/config/setConfig.ts
@@ -10,12 +10,19 @@ export function setConfig(desiredConfig: Record<string, unknown>): void {
   try {
     const config = getConfig();
 
+    console.log({ config });
+
     const updatedConfig = deepMerge(config, desiredConfig);
+
+    console.log({ updatedConfig });
 
     const sessionUserConfigPath = resolveSessionUserConfigPath();
     const iniConfigFilePath = join(sessionUserConfigPath, "nvda.ini");
 
+    console.log({ sessionUserConfigPath, iniConfigFilePath });
+
     const builtConfig = buildIni(updatedConfig);
+    console.log(builtConfig);
 
     writeFileSync(iniConfigFilePath, builtConfig);
   } catch (cause) {

--- a/src/windows/NVDA/config/setConfig.ts
+++ b/src/windows/NVDA/config/setConfig.ts
@@ -1,0 +1,1 @@
+export const setConfig = (desiredConfig: Record<string, unknown>) => {};

--- a/src/windows/NVDA/config/setConfig.ts
+++ b/src/windows/NVDA/config/setConfig.ts
@@ -1,4 +1,5 @@
 import { buildIni } from "./buildIni";
+import { deepMerge } from "../../../deepMerge";
 import { ERR_NVDA_FAILED_TO_SET_SETTING } from "../../errors";
 import { getConfig } from "./getConfig";
 import { join } from "node:path";
@@ -9,20 +10,12 @@ export function setConfig(desiredConfig: Record<string, unknown>): void {
   try {
     const config = getConfig();
 
-    console.log(JSON.stringify({ config, desiredConfig }, undefined, 2));
-
-    const updatedConfig = {
-      ...config,
-      desiredConfig,
-    };
+    const updatedConfig = deepMerge(config, desiredConfig);
 
     const sessionUserConfigPath = resolveSessionUserConfigPath();
     const iniConfigFilePath = join(sessionUserConfigPath, "nvda.ini");
 
     const builtConfig = buildIni(updatedConfig);
-
-    console.log({ iniConfigFilePath });
-    console.log(builtConfig);
 
     writeFileSync(iniConfigFilePath, builtConfig);
   } catch (cause) {

--- a/src/windows/NVDA/config/setConfig.ts
+++ b/src/windows/NVDA/config/setConfig.ts
@@ -9,6 +9,8 @@ export function setConfig(desiredConfig: Record<string, unknown>): void {
   try {
     const config = getConfig();
 
+    console.log(JSON.stringify({ config, desiredConfig }, undefined, 2));
+
     const updatedConfig = {
       ...config,
       desiredConfig,
@@ -17,7 +19,12 @@ export function setConfig(desiredConfig: Record<string, unknown>): void {
     const sessionUserConfigPath = resolveSessionUserConfigPath();
     const iniConfigFilePath = join(sessionUserConfigPath, "nvda.ini");
 
-    writeFileSync(iniConfigFilePath, buildIni(updatedConfig));
+    const builtConfig = buildIni(updatedConfig);
+
+    console.log({ iniConfigFilePath });
+    console.log(builtConfig);
+
+    writeFileSync(iniConfigFilePath, builtConfig);
   } catch (cause) {
     throw new Error(ERR_NVDA_FAILED_TO_SET_SETTING, { cause });
   }

--- a/src/windows/NVDA/config/setConfig.ts
+++ b/src/windows/NVDA/config/setConfig.ts
@@ -1,1 +1,24 @@
-export const setConfig = (desiredConfig: Record<string, unknown>) => {};
+import { buildIni } from "./buildIni";
+import { ERR_NVDA_FAILED_TO_SET_SETTING } from "../../errors";
+import { getConfig } from "./getConfig";
+import { join } from "node:path";
+import { resolveSessionUserConfigPath } from "./resolveSessionUserConfigPath";
+import { writeFileSync } from "node:fs";
+
+export function setConfig(desiredConfig: Record<string, unknown>): void {
+  try {
+    const config = getConfig();
+
+    const updatedConfig = {
+      ...config,
+      desiredConfig,
+    };
+
+    const sessionUserConfigPath = resolveSessionUserConfigPath();
+    const iniConfigFilePath = join(sessionUserConfigPath, "nvda.ini");
+
+    writeFileSync(iniConfigFilePath, buildIni(updatedConfig));
+  } catch (cause) {
+    throw new Error(ERR_NVDA_FAILED_TO_SET_SETTING, { cause });
+  }
+}

--- a/src/windows/NVDA/config/setConfig.ts
+++ b/src/windows/NVDA/config/setConfig.ts
@@ -9,20 +9,10 @@ import { writeFileSync } from "node:fs";
 export function setConfig(desiredConfig: Record<string, unknown>): void {
   try {
     const config = getConfig();
-
-    console.log({ config });
-
     const updatedConfig = deepMerge(config, desiredConfig);
-
-    console.log({ updatedConfig });
-
     const sessionUserConfigPath = resolveSessionUserConfigPath();
     const iniConfigFilePath = join(sessionUserConfigPath, "nvda.ini");
-
-    console.log({ sessionUserConfigPath, iniConfigFilePath });
-
     const builtConfig = buildIni(updatedConfig);
-    console.log(builtConfig);
 
     writeFileSync(iniConfigFilePath, builtConfig);
   } catch (cause) {

--- a/src/windows/NVDA/start.test.ts
+++ b/src/windows/NVDA/start.test.ts
@@ -71,7 +71,7 @@ describe("start", () => {
 
       it("should spawn a NVDA command", () => {
         expect(spawn).toHaveBeenCalledWith(
-          `"${mockInstallationPath}"`,
+          mockInstallationPath,
           ["--config-path", mockSessionUserConfigPath],
           {
             shell: true,
@@ -102,7 +102,7 @@ describe("start", () => {
 
       it("should spawn a NVDA command", () => {
         expect(spawn).toHaveBeenCalledWith(
-          `"${mockInstallationPath}"`,
+          mockInstallationPath,
           ["--config-path", mockSessionUserConfigPath],
           {
             shell: true,
@@ -132,7 +132,7 @@ describe("start", () => {
       it("should spawn a NVDA command", () => {
         expect(spawn).toHaveBeenNthCalledWith(
           1,
-          `"${mockInstallationPath}"`,
+          mockInstallationPath,
           ["--config-path", mockSessionUserConfigPath],
           {
             shell: true,
@@ -152,7 +152,7 @@ describe("start", () => {
       it("should attempt to spawn a NVDA command again", () => {
         expect(spawn).toHaveBeenNthCalledWith(
           2,
-          `"${mockInstallationPath}"`,
+          mockInstallationPath,
           ["--config-path", mockSessionUserConfigPath],
           {
             shell: true,
@@ -185,7 +185,7 @@ describe("start", () => {
       it("should spawn a NVDA command", () => {
         expect(spawn).toHaveBeenNthCalledWith(
           1,
-          `"${mockInstallationPath}"`,
+          mockInstallationPath,
           ["--config-path", mockSessionUserConfigPath],
           {
             shell: true,
@@ -205,7 +205,7 @@ describe("start", () => {
       it("should attempt to spawn a NVDA command again", () => {
         expect(spawn).toHaveBeenNthCalledWith(
           2,
-          `"${mockInstallationPath}"`,
+          mockInstallationPath,
           ["--config-path", mockSessionUserConfigPath],
           {
             shell: true,

--- a/src/windows/NVDA/start.test.ts
+++ b/src/windows/NVDA/start.test.ts
@@ -1,11 +1,15 @@
 import { ChildProcess, spawn } from "child_process";
 import { ERR_NVDA_CANNOT_BE_STARTED, ERR_NVDA_NOT_INSTALLED } from "../errors";
 import { getNVDAInstallationPath } from "./getNVDAInstallationPath";
+import { resolveSessionUserConfigPath } from "./config";
 import { start } from "./start";
 import { waitForRunning } from "./waitForRunning";
 
 jest.mock("./getNVDAInstallationPath", () => ({
   getNVDAInstallationPath: jest.fn(),
+}));
+jest.mock("./config", () => ({
+  resolveSessionUserConfigPath: jest.fn(),
 }));
 jest.mock("child_process", () => ({
   spawn: jest.fn(),
@@ -15,6 +19,7 @@ jest.mock("./waitForRunning", () => ({
 }));
 
 const mockInstallationPath = "test-installation-path";
+const mockSessionUserConfigPath = "test-session-user-config-path";
 const mockChildProcess = {
   kill: jest.fn(),
 };
@@ -28,6 +33,7 @@ describe("start", () => {
   describe("when NVDA is not installed", () => {
     beforeEach(() => {
       jest.mocked(getNVDAInstallationPath).mockReturnValue(null);
+      jest.mocked(resolveSessionUserConfigPath).mockReturnValue("");
     });
 
     it("should attempt to get the installation path", async () => {
@@ -50,6 +56,10 @@ describe("start", () => {
       jest
         .mocked(getNVDAInstallationPath)
         .mockReturnValue(mockInstallationPath);
+
+      jest
+        .mocked(resolveSessionUserConfigPath)
+        .mockReturnValue(mockSessionUserConfigPath);
     });
 
     describe("when starting NVDA is successful first attempt", () => {
@@ -60,10 +70,14 @@ describe("start", () => {
       });
 
       it("should spawn a NVDA command", () => {
-        expect(spawn).toHaveBeenCalledWith(`"${mockInstallationPath}"`, [], {
-          shell: true,
-          stdio: "ignore",
-        });
+        expect(spawn).toHaveBeenCalledWith(
+          `"${mockInstallationPath}"`,
+          ["--config-path", mockSessionUserConfigPath],
+          {
+            shell: true,
+            stdio: "ignore",
+          },
+        );
       });
 
       it("should wait for NVDA to be running", () => {
@@ -87,10 +101,14 @@ describe("start", () => {
       });
 
       it("should spawn a NVDA command", () => {
-        expect(spawn).toHaveBeenCalledWith(`"${mockInstallationPath}"`, [], {
-          shell: true,
-          stdio: "ignore",
-        });
+        expect(spawn).toHaveBeenCalledWith(
+          `"${mockInstallationPath}"`,
+          ["--config-path", mockSessionUserConfigPath],
+          {
+            shell: true,
+            stdio: "ignore",
+          },
+        );
       });
 
       it("should throw a wrapped error", () => {
@@ -115,7 +133,7 @@ describe("start", () => {
         expect(spawn).toHaveBeenNthCalledWith(
           1,
           `"${mockInstallationPath}"`,
-          [],
+          ["--config-path", mockSessionUserConfigPath],
           {
             shell: true,
             stdio: "ignore",
@@ -135,7 +153,7 @@ describe("start", () => {
         expect(spawn).toHaveBeenNthCalledWith(
           2,
           `"${mockInstallationPath}"`,
-          [],
+          ["--config-path", mockSessionUserConfigPath],
           {
             shell: true,
             stdio: "ignore",
@@ -168,7 +186,7 @@ describe("start", () => {
         expect(spawn).toHaveBeenNthCalledWith(
           1,
           `"${mockInstallationPath}"`,
-          [],
+          ["--config-path", mockSessionUserConfigPath],
           {
             shell: true,
             stdio: "ignore",
@@ -188,7 +206,7 @@ describe("start", () => {
         expect(spawn).toHaveBeenNthCalledWith(
           2,
           `"${mockInstallationPath}"`,
-          [],
+          ["--config-path", mockSessionUserConfigPath],
           {
             shell: true,
             stdio: "ignore",

--- a/src/windows/NVDA/start.ts
+++ b/src/windows/NVDA/start.ts
@@ -1,8 +1,8 @@
 import { ChildProcess, spawn } from "child_process";
 import { ERR_NVDA_CANNOT_BE_STARTED, ERR_NVDA_NOT_INSTALLED } from "../errors";
 import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { getNVDAInstallationPath } from "./getNVDAInstallationPath";
-import { join } from "node:path";
 import { resolveSessionUserConfigPath } from "./config";
 import { waitForRunning } from "./waitForRunning";
 
@@ -32,8 +32,8 @@ export async function start(): Promise<void> {
       nvdaProcess = spawn(
         executablePath,
         [
-          // "--config-path",
-          // sessionUserConfigPath,
+          "--config-path",
+          resolve(sessionUserConfigPath, ".."),
           "--log-file",
           logFilePath,
           "--debug-logging",

--- a/src/windows/NVDA/start.ts
+++ b/src/windows/NVDA/start.ts
@@ -1,8 +1,8 @@
 import { ChildProcess, spawn } from "child_process";
 import { ERR_NVDA_CANNOT_BE_STARTED, ERR_NVDA_NOT_INSTALLED } from "../errors";
 import { existsSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
 import { getNVDAInstallationPath } from "./getNVDAInstallationPath";
+import { join } from "node:path";
 import { resolveSessionUserConfigPath } from "./config";
 import { waitForRunning } from "./waitForRunning";
 

--- a/src/windows/NVDA/start.ts
+++ b/src/windows/NVDA/start.ts
@@ -1,6 +1,8 @@
 import { ChildProcess, spawn } from "child_process";
 import { ERR_NVDA_CANNOT_BE_STARTED, ERR_NVDA_NOT_INSTALLED } from "../errors";
+import { existsSync, readFileSync } from "node:fs";
 import { getNVDAInstallationPath } from "./getNVDAInstallationPath";
+import { join } from "node:path";
 import { resolveSessionUserConfigPath } from "./config";
 import { waitForRunning } from "./waitForRunning";
 
@@ -15,9 +17,12 @@ export async function start(): Promise<void> {
 
   const sessionUserConfigPath = resolveSessionUserConfigPath();
 
+  const logFilePath = join(sessionUserConfigPath, "nvda.log");
+
   console.log({
     executablePath,
     sessionUserConfigPath,
+    logFilePath,
   });
 
   for (let attempt = 0; attempt < MAX_START_ATTEMPTS; attempt++) {
@@ -26,7 +31,14 @@ export async function start(): Promise<void> {
     try {
       nvdaProcess = spawn(
         executablePath,
-        ["--config-path", sessionUserConfigPath, "--log-level", "DEBUG"],
+        [
+          "--config-path",
+          sessionUserConfigPath,
+          "--log-file",
+          logFilePath,
+          "--log-level",
+          "DEBUG",
+        ],
         {
           shell: true,
           stdio: ["ignore", "pipe", "pipe"],
@@ -43,6 +55,13 @@ export async function start(): Promise<void> {
 
       nvdaProcess.on("exit", (code, signal) => {
         console.log("NVDA exited", { code, signal });
+
+        if (existsSync(logFilePath)) {
+          console.log("NVDA log:");
+          console.log(readFileSync(logFilePath, "utf8"));
+        } else {
+          console.log("NVDA log not found:", logFilePath);
+        }
       });
     } catch (e) {
       throw new Error(`${ERR_NVDA_CANNOT_BE_STARTED}\n${e.message}`, {

--- a/src/windows/NVDA/start.ts
+++ b/src/windows/NVDA/start.ts
@@ -33,7 +33,7 @@ export async function start(): Promise<void> {
         executablePath,
         [
           "--config-path",
-          resolve(sessionUserConfigPath, ".."),
+          sessionUserConfigPath,
           "--log-file",
           logFilePath,
           "--debug-logging",

--- a/src/windows/NVDA/start.ts
+++ b/src/windows/NVDA/start.ts
@@ -15,18 +15,35 @@ export async function start(): Promise<void> {
 
   const sessionUserConfigPath = resolveSessionUserConfigPath();
 
+  console.log({
+    executablePath,
+    sessionUserConfigPath,
+  });
+
   for (let attempt = 0; attempt < MAX_START_ATTEMPTS; attempt++) {
     let nvdaProcess: ChildProcess;
 
     try {
       nvdaProcess = spawn(
-        `"${executablePath}"`,
+        executablePath,
         ["--config-path", sessionUserConfigPath],
         {
           shell: true,
-          stdio: "ignore",
+          stdio: ["ignore", "pipe", "pipe"],
         },
       );
+
+      nvdaProcess.stdout?.on("data", (data) => {
+        console.log("NVDA stdout:", data.toString());
+      });
+
+      nvdaProcess.stderr?.on("data", (data) => {
+        console.error("NVDA stderr:", data.toString());
+      });
+
+      nvdaProcess.on("exit", (code, signal) => {
+        console.log("NVDA exited", { code, signal });
+      });
     } catch (e) {
       throw new Error(`${ERR_NVDA_CANNOT_BE_STARTED}\n${e.message}`, {
         cause: e,

--- a/src/windows/NVDA/start.ts
+++ b/src/windows/NVDA/start.ts
@@ -32,12 +32,11 @@ export async function start(): Promise<void> {
       nvdaProcess = spawn(
         executablePath,
         [
-          "--config-path",
-          sessionUserConfigPath,
+          // "--config-path",
+          // sessionUserConfigPath,
           "--log-file",
           logFilePath,
-          "--log-level",
-          "DEBUG",
+          "--debug-logging",
         ],
         {
           shell: true,

--- a/src/windows/NVDA/start.ts
+++ b/src/windows/NVDA/start.ts
@@ -26,7 +26,7 @@ export async function start(): Promise<void> {
     try {
       nvdaProcess = spawn(
         executablePath,
-        ["--config-path", sessionUserConfigPath],
+        ["--config-path", sessionUserConfigPath, "--log-level", "DEBUG"],
         {
           shell: true,
           stdio: ["ignore", "pipe", "pipe"],

--- a/src/windows/NVDA/start.ts
+++ b/src/windows/NVDA/start.ts
@@ -1,6 +1,7 @@
 import { ChildProcess, spawn } from "child_process";
 import { ERR_NVDA_CANNOT_BE_STARTED, ERR_NVDA_NOT_INSTALLED } from "../errors";
 import { getNVDAInstallationPath } from "./getNVDAInstallationPath";
+import { resolveSessionUserConfigPath } from "./config";
 import { waitForRunning } from "./waitForRunning";
 
 const MAX_START_ATTEMPTS = 2;
@@ -12,14 +13,20 @@ export async function start(): Promise<void> {
     throw new Error(ERR_NVDA_NOT_INSTALLED);
   }
 
+  const sessionUserConfigPath = resolveSessionUserConfigPath();
+
   for (let attempt = 0; attempt < MAX_START_ATTEMPTS; attempt++) {
     let nvdaProcess: ChildProcess;
 
     try {
-      nvdaProcess = spawn(`"${executablePath}"`, [], {
-        shell: true,
-        stdio: "ignore",
-      });
+      nvdaProcess = spawn(
+        `"${executablePath}"`,
+        ["--config-path", sessionUserConfigPath],
+        {
+          shell: true,
+          stdio: "ignore",
+        },
+      );
     } catch (e) {
       throw new Error(`${ERR_NVDA_CANNOT_BE_STARTED}\n${e.message}`, {
         cause: e,

--- a/src/windows/NVDA/start.ts
+++ b/src/windows/NVDA/start.ts
@@ -1,8 +1,6 @@
 import { ChildProcess, spawn } from "child_process";
 import { ERR_NVDA_CANNOT_BE_STARTED, ERR_NVDA_NOT_INSTALLED } from "../errors";
-import { existsSync, readFileSync } from "node:fs";
 import { getNVDAInstallationPath } from "./getNVDAInstallationPath";
-import { join } from "node:path";
 import { resolveSessionUserConfigPath } from "./config";
 import { waitForRunning } from "./waitForRunning";
 
@@ -17,51 +15,18 @@ export async function start(): Promise<void> {
 
   const sessionUserConfigPath = resolveSessionUserConfigPath();
 
-  const logFilePath = join(sessionUserConfigPath, "nvda.log");
-
-  console.log({
-    executablePath,
-    sessionUserConfigPath,
-    logFilePath,
-  });
-
   for (let attempt = 0; attempt < MAX_START_ATTEMPTS; attempt++) {
     let nvdaProcess: ChildProcess;
 
     try {
       nvdaProcess = spawn(
         executablePath,
-        [
-          "--config-path",
-          sessionUserConfigPath,
-          "--log-file",
-          logFilePath,
-          "--debug-logging",
-        ],
+        ["--config-path", sessionUserConfigPath],
         {
           shell: true,
-          stdio: ["ignore", "pipe", "pipe"],
+          stdio: "ignore",
         },
       );
-
-      nvdaProcess.stdout?.on("data", (data) => {
-        console.log("NVDA stdout:", data.toString());
-      });
-
-      nvdaProcess.stderr?.on("data", (data) => {
-        console.error("NVDA stderr:", data.toString());
-      });
-
-      nvdaProcess.on("exit", (code, signal) => {
-        console.log("NVDA exited", { code, signal });
-
-        if (existsSync(logFilePath)) {
-          console.log("NVDA log:");
-          console.log(readFileSync(logFilePath, "utf8"));
-        } else {
-          console.log("NVDA log not found:", logFilePath);
-        }
-      });
     } catch (e) {
       throw new Error(`${ERR_NVDA_CANNOT_BE_STARTED}\n${e.message}`, {
         cause: e,

--- a/src/windows/errors.ts
+++ b/src/windows/errors.ts
@@ -1,5 +1,7 @@
 export const ERR_NVDA_NOT_INSTALLED =
   "NVDA is not installed\n\nPlease ensure you have run:\n\n\t- `npx @guidepup/setup setup` at least once on your machine to configure the OS\n\t- `npx @guidepup/setup install` at least once for this project to install screen reader assets";
+export const ERR_NVDA_FAILED_TO_CREATE_GUIDEPUP_PREFERENCES =
+  "Failed to create Guidepup preferences\n\nPlease ensure you have run:\n\n\t- `npx @guidepup/setup setup` at least once on your machine to configure the OS\n\t- `npx @guidepup/setup install` at least once for this project to install screen reader assets";
 export const ERR_NVDA_NOT_SUPPORTED = "NVDA is not supported";
 export const ERR_NVDA_ALREADY_RUNNING = "NVDA is already running";
 export const ERR_NVDA_NOT_RUNNING = "NVDA is not running";

--- a/src/windows/errors.ts
+++ b/src/windows/errors.ts
@@ -12,3 +12,7 @@ export const ERR_NVDA_RUNNING_TIMEOUT =
   "Timed out waiting for NVDA to be running";
 
 export const ERR_SEND_KEYS = "Unable to send keys";
+
+export const ERR_NVDA_FAILED_TO_GET_SETTINGS = "Failed to get NVDA settings";
+export const ERR_NVDA_FAILED_TO_SET_SETTING = "Failed to set NVDA setting";
+export const ERR_NVDA_UNSUPPORTED_SETTING = "Unsupported NVDA setting: ";


### PR DESCRIPTION
# Issue

Fixes #75 

## Details

Implements new `settings` `.start()` option for overriding screen reader settings, and new getter methods for reading the current screen reader settings:

```ts
  /**
   * Turn the screen reader on.
   *
   * @param {object} [options] Additional options.
   */
  start(options?: StartOptions): Promise<void>;

  /**
   * Returns all the current settings for this screen reader instance.
   *
   * @returns {Record<string, unknown>} Current settings values.
   */
  getSettings(): Record<string, unknown>;

  /**
   * Returns the value of a setting for this screen reader instance.
   *
   * @param key The setting name.
   * @returns {unknown} The setting value.
   */
  getSetting(key: string): unknown;
```

```ts
interface StartOptions extends CommandOptions {
  /**
   * Screen reader settings to apply on startup.
   */
  settings?: Record<string, unknown>;
}
```

Setting overrides persist only for the duration of a screen reader instance, i.e. from `.start()` until `.stop()` is called.

### Examples

Here we start NVDA with settings overrides for the voice to use and overrides to disable the NVDA highlighter (enabled by default for Guidepup NVDA):

```ts
await nvda.start({
  settings: {
    speech: {
      oneCore: {
        voice:
          "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Speech_OneCore\\Voices\\Tokens\\MSTTS_V110_enGB_SusanM",
      },
    },
    vision: {
      NVDAHighlighter: {
        highlightFocus: false,
        highlightNavigator: false,
        highlightBrowseMode: false,
        enabled: false,
      },
    },
  },
});
```

Here we start VoiceOver with settings overrides for the voice to use:

```ts
await voiceOverPlaywright.start({
  settings: {
    SCRCategories_SCRCategorySystemWide_SCRSpeechLanguages_default_SCRSpeechComponentSettings_SCRVoiceIdentifier:
      "com.apple.speech.synthesis.voice.custom.siri.martha.compact",
  },
});
```

## CheckList

- [ ] Has been tested (where required).
