### PR TITLE
feat: getters for screen reader version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,35 +22,35 @@
       "defaultDownload": true,
       "assets": [
         {
-          "version": "0.0.1",
+          "version": "0.0.1-VoiceOver4",
           "platformVersion": "21",
           "repository": "guidepup/voiceover",
           "asset": "guidepup-voiceover-preferences-macos-14.dmg",
           "sha256": "c6595f5ca50440e8553cde278936a46eff58d4c904e19c87e7d0e25950617ee1"
         },
         {
-          "version": "0.0.1",
+          "version": "0.0.1-VoiceOver4",
           "platformVersion": "22",
           "repository": "guidepup/voiceover",
           "asset": "guidepup-voiceover-preferences-macos-14.dmg",
           "sha256": "c6595f5ca50440e8553cde278936a46eff58d4c904e19c87e7d0e25950617ee1"
         },
         {
-          "version": "0.0.1",
+          "version": "0.0.1-VoiceOver4",
           "platformVersion": "23",
           "repository": "guidepup/voiceover",
           "asset": "guidepup-voiceover-preferences-macos-14.dmg",
           "sha256": "c6595f5ca50440e8553cde278936a46eff58d4c904e19c87e7d0e25950617ee1"
         },
         {
-          "version": "0.0.1",
+          "version": "0.0.1-VoiceOver4",
           "platformVersion": "24",
           "repository": "guidepup/voiceover",
           "asset": "guidepup-voiceover-preferences-macos-15.dmg",
           "sha256": "8bdc3a11c45a19cc876a859bfbd64529469a8b7d4ad41fd7e00a0729ebdbcb25"
         },
         {
-          "version": "0.0.1",
+          "version": "0.0.1-VoiceOver4",
           "platformVersion": "25",
           "repository": "guidepup/voiceover",
           "asset": "guidepup-voiceover-preferences-macos-26.dmg",

--- a/manifest.json
+++ b/manifest.json
@@ -26,35 +26,35 @@
           "platformVersion": "21",
           "repository": "guidepup/voiceover",
           "asset": "guidepup-voiceover-preferences-macos-14.dmg",
-          "sha256": "c6595f5ca50440e8553cde278936a46eff58d4c904e19c87e7d0e25950617ee1"
+          "sha256": "fd88500b740bb3389ec295465d35a5351d49a57fe120983aed3c761cfb349c6a"
         },
         {
           "version": "0.0.1-VoiceOver4",
           "platformVersion": "22",
           "repository": "guidepup/voiceover",
           "asset": "guidepup-voiceover-preferences-macos-14.dmg",
-          "sha256": "c6595f5ca50440e8553cde278936a46eff58d4c904e19c87e7d0e25950617ee1"
+          "sha256": "fd88500b740bb3389ec295465d35a5351d49a57fe120983aed3c761cfb349c6a"
         },
         {
           "version": "0.0.1-VoiceOver4",
           "platformVersion": "23",
           "repository": "guidepup/voiceover",
           "asset": "guidepup-voiceover-preferences-macos-14.dmg",
-          "sha256": "c6595f5ca50440e8553cde278936a46eff58d4c904e19c87e7d0e25950617ee1"
+          "sha256": "fd88500b740bb3389ec295465d35a5351d49a57fe120983aed3c761cfb349c6a"
         },
         {
           "version": "0.0.1-VoiceOver4",
           "platformVersion": "24",
           "repository": "guidepup/voiceover",
           "asset": "guidepup-voiceover-preferences-macos-15.dmg",
-          "sha256": "8bdc3a11c45a19cc876a859bfbd64529469a8b7d4ad41fd7e00a0729ebdbcb25"
+          "sha256": "ef5a533e38f37aff44682b125b07855b4cd0eb24d04416d48df5097386580799"
         },
         {
           "version": "0.0.1-VoiceOver4",
           "platformVersion": "25",
           "repository": "guidepup/voiceover",
           "asset": "guidepup-voiceover-preferences-macos-26.dmg",
-          "sha256": "9af2a3af7c9bffae1b2af26f1970548ecd62f33965fd30f4e43f21b9f57ce5ca"
+          "sha256": "c46e353d4f2d4a717d3362211de638ee55fcb58dbec9cf9abd0170c35d41b225"
         }
       ]
     }

--- a/src/IScreenReader.ts
+++ b/src/IScreenReader.ts
@@ -10,6 +10,11 @@ export interface IScreenReader {
   name: string;
 
   /**
+   * The screen reader version.
+   */
+  version: string;
+
+  /**
    * Detect whether the screen reader is supported for the current OS.
    *
    * @returns {boolean}

--- a/src/ScreenReader.test.ts
+++ b/src/ScreenReader.test.ts
@@ -7,6 +7,7 @@ jest.mock("./windows", () => ({
   nvda: {
     default: jest.fn(),
     name: "NVDA",
+    version: "test-nvda-version",
   },
 }));
 
@@ -14,6 +15,7 @@ jest.mock("./macOS", () => ({
   voiceOver: {
     default: jest.fn(),
     name: "VoiceOver",
+    version: "test-vo-version",
   },
 }));
 
@@ -36,6 +38,14 @@ describe("ScreenReader", () => {
         expect(screenReader.name).toBe("VoiceOver");
       });
     });
+
+    describe("version", () => {
+      it("should return the VoiceOver version", () => {
+        const screenReader = new ScreenReader();
+
+        expect(screenReader.version).toBe("test-vo-version");
+      });
+    });
   });
 
   describe("when NVDA is the default screen reader for the environment", () => {
@@ -51,6 +61,14 @@ describe("ScreenReader", () => {
         expect(screenReader.name).toBe("NVDA");
       });
     });
+
+    describe("version", () => {
+      it("should return the NVDA version", () => {
+        const screenReader = new ScreenReader();
+
+        expect(screenReader.version).toBe("test-nvda-version");
+      });
+    });
   });
 
   describe("when neither VoiceOver nor NVDA is the default screen reader for the environment", () => {
@@ -59,12 +77,10 @@ describe("ScreenReader", () => {
       jest.mocked(voiceOver.default).mockReturnValue(false);
     });
 
-    describe("name", () => {
-      it("should return NVDA", () => {
-        expect(() => new ScreenReader()).toThrow(
-          new Error(ERR_NO_AVAILABLE_SUPPORTED_SCREEN_READERS),
-        );
-      });
+    it("should throw an error", () => {
+      expect(() => new ScreenReader()).toThrow(
+        new Error(ERR_NO_AVAILABLE_SUPPORTED_SCREEN_READERS),
+      );
     });
   });
 });

--- a/src/ScreenReader.ts
+++ b/src/ScreenReader.ts
@@ -34,6 +34,13 @@ export class ScreenReader implements IScreenReader {
   }
 
   /**
+   * The screen reader version.
+   */
+  get version(): string {
+    return this.implementation.version;
+  }
+
+  /**
    * Detect whether the screen reader is supported for the current OS.
    *
    * @returns {boolean}

--- a/src/macOS/VoiceOver/VoiceOver.test.ts
+++ b/src/macOS/VoiceOver/VoiceOver.test.ts
@@ -1,4 +1,5 @@
 import {
+  ERR_MACOS_VERSION_NOT_SUPPORTED,
   ERR_VOICE_OVER_ALREADY_RUNNING,
   ERR_VOICE_OVER_CANNOT_BE_STARTED,
   ERR_VOICE_OVER_NOT_RUNNING,
@@ -15,6 +16,7 @@ import { CommanderCommands } from "./CommanderCommands";
 import { delay } from "../../delay";
 import { isKeyboard } from "../../isKeyboard";
 import { isMacOS } from "../isMacOS";
+import { release } from "node:os";
 import { start } from "./start";
 import { terminateVoiceOverProcess } from "./terminateVoiceOverProcess";
 import { VoiceOver } from "./VoiceOver";
@@ -27,6 +29,22 @@ import { VoiceOverMouse } from "./VoiceOverMouse";
 import { waitForNotRunning } from "./waitForNotRunning";
 import { waitForRunning } from "./waitForRunning";
 
+jest.mock("../../../manifest.json", () => ({
+  screenReaders: [
+    {
+      id: "voiceover",
+      assets: [
+        {
+          version: "test-version",
+          platformVersion: "123",
+        },
+      ],
+    },
+  ],
+}));
+jest.mock("node:os", () => ({
+  release: jest.fn(),
+}));
 jest.mock("../activate", () => ({
   activate: jest.fn(),
 }));
@@ -145,6 +163,8 @@ describe("VoiceOver", () => {
     jest.mocked(getPreferences).mockReturnValue({});
     jest.mocked(getPreference).mockReturnValue(undefined);
 
+    jest.mocked(release).mockReturnValue("123.0.0");
+
     vo = new VoiceOver();
     result = undefined;
   });
@@ -152,6 +172,21 @@ describe("VoiceOver", () => {
   describe("name", () => {
     it("should return VoiceOver", () => {
       expect(vo.name).toBe("VoiceOver");
+    });
+  });
+
+  describe("version", () => {
+    it("should return the VoiceOver version for supported versions of macOS", () => {
+      expect(vo.version).toBe("test-version");
+    });
+
+    it("should throw an error for unsupported versions of macOS", () => {
+      jest.clearAllMocks();
+      jest.mocked(release).mockReturnValue("321.0.0");
+
+      vo = new VoiceOver();
+
+      expect(() => vo.version).toThrow(ERR_MACOS_VERSION_NOT_SUPPORTED);
     });
   });
 

--- a/src/macOS/VoiceOver/VoiceOver.ts
+++ b/src/macOS/VoiceOver/VoiceOver.ts
@@ -1,4 +1,5 @@
 import {
+  ERR_MACOS_VERSION_NOT_SUPPORTED,
   ERR_VOICE_OVER_ALREADY_RUNNING,
   ERR_VOICE_OVER_CANNOT_BE_STARTED,
   ERR_VOICE_OVER_NOT_RUNNING,
@@ -20,6 +21,7 @@ import { isMacOS } from "../isMacOS";
 import { KeyboardCommand } from "../KeyboardCommand";
 import { KeyboardOptions } from "../../KeyboardOptions";
 import type { Prettify } from "../../typeHelpers";
+import { release } from "node:os";
 import { start } from "./start";
 import type { StartOptions } from "../../StartOptions";
 import { terminateVoiceOverProcess } from "./terminateVoiceOverProcess";
@@ -31,6 +33,9 @@ import { VoiceOverKeyboard } from "./VoiceOverKeyboard";
 import { VoiceOverMouse } from "./VoiceOverMouse";
 import { waitForNotRunning } from "./waitForNotRunning";
 import { waitForRunning } from "./waitForRunning";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const manifest = require("../../../manifest.json");
 
 type CommandOptionsWithoutCapture = Prettify<Omit<CommandOptions, "capture">>;
 
@@ -93,6 +98,23 @@ export class VoiceOver implements IScreenReader {
    */
   get name(): string {
     return "VoiceOver";
+  }
+
+  /**
+   * The screen reader version.
+   */
+  get version(): string {
+    const osVersion = release().split(".", 1)[0];
+
+    const asset = manifest.screenReaders
+      .find(({ id }) => id === "voiceover")
+      .assets.find(({ platformVersion }) => platformVersion === osVersion);
+
+    if (!asset) {
+      throw new Error(ERR_MACOS_VERSION_NOT_SUPPORTED);
+    }
+
+    return asset.version;
   }
 
   /**

--- a/src/windows/NVDA/NVDA.test.ts
+++ b/src/windows/NVDA/NVDA.test.ts
@@ -11,6 +11,21 @@ import { NVDAClient } from "./NVDAClient";
 import { quit } from "./quit";
 import { start } from "./start";
 
+jest.mock("../../../manifest.json", () => {
+  return {
+    screenReaders: [
+      {
+        id: "nvda",
+        assets: [
+          {
+            version: "test-version",
+          },
+        ],
+      },
+    ],
+  };
+});
+
 jest.mock("./config", () => ({
   createGuidepupConfig: jest.fn(),
   deleteGuidepupConfig: jest.fn(),
@@ -60,6 +75,14 @@ describe("NVDA", () => {
       nvda = new NVDA();
 
       expect(nvda.name).toBe("NVDA");
+    });
+  });
+
+  describe("version", () => {
+    it("should return the NVDA version", () => {
+      nvda = new NVDA();
+
+      expect(nvda.version).toBe("test-version");
     });
   });
 

--- a/src/windows/NVDA/NVDA.ts
+++ b/src/windows/NVDA/NVDA.ts
@@ -29,6 +29,9 @@ import { sendKeys } from "../sendKeys";
 import { start } from "./start";
 import type { StartOptions } from "../../StartOptions";
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const manifest = require("../../../manifest.json");
+
 type CaptureCommandOptions = Prettify<Pick<CommandOptions, "capture">>;
 type CaptureStartOptions = Prettify<Pick<StartOptions, "capture" | "settings">>;
 
@@ -61,6 +64,14 @@ export class NVDA implements IScreenReader {
    */
   get name(): string {
     return "NVDA";
+  }
+
+  /**
+   * The screen reader version.
+   */
+  get version(): string {
+    return manifest.screenReaders.find(({ id }) => id === "nvda").assets[0]
+      .version;
   }
 
   /**


### PR DESCRIPTION
# Issue

Fixes #126 

## Details

New getters for the version of the Guidepup screen reader instance + settins snapshot.

```ts
console.log(screenReader.version);
console.log(nvda.version);
console.log(voiceOver.version);
```

## CheckList

- [x] Has been tested (where required).
