### PR TITLE
feat: common navigation command APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ import { voiceOver } from "@guidepup/guidepup";
 (async () => {
   await voiceOver.start();
 
-  await voiceOver.perform(voiceOver.keyboardCommands.findNextHeading);
+  await voiceOver.nextHeading();
   console.log(await voiceOver.itemText());
 
   await voiceOver.perform(voiceOver.keyboardCommands.findNextControl);
@@ -131,7 +131,7 @@ import { nvda } from "@guidepup/guidepup";
 (async () => {
   await nvda.start();
 
-  await nvda.perform(nvda.keyboardCommands.moveToNextHeading);
+  await nvda.nextHeading();
   console.log(await nvda.itemText());
 
   await nvda.perform(nvda.keyboardCommands.moveToNextFormField);

--- a/examples/playwright-nvda/tests/chromium/chromium.spec.ts
+++ b/examples/playwright-nvda/tests/chromium/chromium.spec.ts
@@ -30,6 +30,8 @@ test.describe("Chromium Playwright NVDA", () => {
     const osName = platform();
     const osVersion = release();
     const browserVersion = browser.version();
+    const screenReaderName = nvda.name;
+    const screenReaderVersion = nvda.version;
     const { retry } = test.info();
     const recordingFilePath = `./recordings/playwright-nvda-${osName}-${osVersion}-${browserName}-${browserVersion}-attempt-${retry}-${+new Date()}.mov`;
 
@@ -38,6 +40,8 @@ test.describe("Chromium Playwright NVDA", () => {
       osVersion,
       browserName,
       browserVersion,
+      screenReaderName,
+      screenReaderVersion,
       retry,
     });
 
@@ -70,6 +74,8 @@ test.describe("Chromium Playwright NVDA", () => {
     const osName = platform();
     const osVersion = release();
     const browserVersion = browser.version();
+    const screenReaderName = nvda.name;
+    const screenReaderVersion = nvda.version;
     const { retry } = test.info();
     const recordingFilePath = `./recordings/playwright-nvda-textarea-${osName}-${osVersion}-${browserName}-${browserVersion}-attempt-${retry}-${+new Date()}.mov`;
 
@@ -78,6 +84,8 @@ test.describe("Chromium Playwright NVDA", () => {
       osVersion,
       browserName,
       browserVersion,
+      screenReaderName,
+      screenReaderVersion,
       retry,
     });
 

--- a/examples/playwright-nvda/tests/firefox/firefox.spec.ts
+++ b/examples/playwright-nvda/tests/firefox/firefox.spec.ts
@@ -26,6 +26,8 @@ test.describe("Firefox Playwright NVDA", () => {
     const osName = platform();
     const osVersion = release();
     const browserVersion = browser.version();
+    const screenReaderName = nvda.name;
+    const screenReaderVersion = nvda.version;
     const { retry } = test.info();
     const recordingFilePath = `./recordings/playwright-nvda-${osName}-${osVersion}-${browserName}-${browserVersion}-attempt-${retry}-${+new Date()}.mov`;
 
@@ -34,6 +36,8 @@ test.describe("Firefox Playwright NVDA", () => {
       osVersion,
       browserName,
       browserVersion,
+      screenReaderName,
+      screenReaderVersion,
       retry,
     });
 

--- a/examples/playwright-nvda/tests/headerNavigation.ts
+++ b/examples/playwright-nvda/tests/headerNavigation.ts
@@ -37,7 +37,7 @@ export async function headerNavigation({
     headingCount++;
 
     log(`Performing command: "H"`);
-    await nvda.perform(nvda.keyboardCommands.moveToNextHeading);
+    await nvda.nextHeading();
     log(`Screen reader output: "${await nvda.lastSpokenPhrase()}".`);
   }
 
@@ -45,9 +45,7 @@ export async function headerNavigation({
 
   // Move across text and buttons using NVDA
   while (
-    !(await nvda.lastSpokenPhrase())
-      .replaceAll(/\s/g, "")
-      .includes("GitHub") &&
+    !(await nvda.lastSpokenPhrase()).replaceAll(/\s/g, "").includes("GitHub") &&
     tabCount <= MAX_NAVIGATION_LOOP
   ) {
     tabCount++;

--- a/examples/playwright-screenreader/tests/chromium/chromium.spec.ts
+++ b/examples/playwright-screenreader/tests/chromium/chromium.spec.ts
@@ -14,6 +14,8 @@ test.describe("Chromium Playwright Screen Reader", () => {
     const osName = platform();
     const osVersion = release();
     const browserVersion = browser.version();
+    const screenReaderName = screenReader.name;
+    const screenReaderVersion = screenReader.version;
     const { retry } = test.info();
 
     console.table({
@@ -21,6 +23,8 @@ test.describe("Chromium Playwright Screen Reader", () => {
       osVersion,
       browserName,
       browserVersion,
+      screenReaderName,
+      screenReaderVersion,
       retry,
     });
 

--- a/examples/playwright-voiceover/tests/chromium/chromium.spec.ts
+++ b/examples/playwright-voiceover/tests/chromium/chromium.spec.ts
@@ -27,6 +27,8 @@ test.describe("Chromium Playwright VoiceOver", () => {
     const osName = platform();
     const osVersion = release();
     const browserVersion = browser.version();
+    const screenReaderName = voiceOver.name;
+    const screenReaderVersion = voiceOver.version;
     const { retry } = test.info();
     const recordingFilePath = `./recordings/playwright-voiceover-${osName}-${osVersion}-${browserName}-${browserVersion}-attempt-${retry}-${+new Date()}.mov`;
 
@@ -35,6 +37,8 @@ test.describe("Chromium Playwright VoiceOver", () => {
       osVersion,
       browserName,
       browserVersion,
+      screenReaderName,
+      screenReaderVersion,
       retry,
     });
 

--- a/examples/playwright-voiceover/tests/firefox/firefox.spec.ts
+++ b/examples/playwright-voiceover/tests/firefox/firefox.spec.ts
@@ -27,6 +27,8 @@ test.describe("Firefox Playwright VoiceOver", () => {
     const osName = platform();
     const osVersion = release();
     const browserVersion = browser.version();
+    const screenReaderName = voiceOver.name;
+    const screenReaderVersion = voiceOver.version;
     const { retry } = test.info();
     const recordingFilePath = `./recordings/playwright-voiceover-${osName}-${osVersion}-${browserName}-${browserVersion}-attempt-${retry}-${+new Date()}.mov`;
 
@@ -35,6 +37,8 @@ test.describe("Firefox Playwright VoiceOver", () => {
       osVersion,
       browserName,
       browserVersion,
+      screenReaderName,
+      screenReaderVersion,
       retry,
     });
 

--- a/examples/playwright-voiceover/tests/headerNavigation.ts
+++ b/examples/playwright-voiceover/tests/headerNavigation.ts
@@ -37,7 +37,7 @@ export async function headerNavigation({
     headingCount++;
 
     log(`Performing command: "VO+Command+H" - "Find the next heading"`);
-    await voiceOver.perform(voiceOver.keyboardCommands.findNextHeading);
+    await voiceOver.nextHeading();
     log(`Screen reader output: "${await voiceOver.lastSpokenPhrase()}".`);
 
     log(

--- a/examples/playwright-voiceover/tests/webkit/webkit.spec.ts
+++ b/examples/playwright-voiceover/tests/webkit/webkit.spec.ts
@@ -31,6 +31,8 @@ test.describe("Webkit Playwright VoiceOver", () => {
     const osName = platform();
     const osVersion = release();
     const browserVersion = browser.version();
+    const screenReaderName = voiceOver.name;
+    const screenReaderVersion = voiceOver.version;
     const { retry } = test.info();
     const recordingFilePath = `./recordings/playwright-voiceover-${osName}-${osVersion}-${browserName}-${browserVersion}-attempt-${retry}-${+new Date()}.mov`;
 
@@ -39,6 +41,8 @@ test.describe("Webkit Playwright VoiceOver", () => {
       osVersion,
       browserName,
       browserVersion,
+      screenReaderName,
+      screenReaderVersion,
       retry,
     });
 
@@ -74,6 +78,8 @@ test.describe("Webkit Playwright VoiceOver", () => {
     const osName = platform();
     const osVersion = release();
     const browserVersion = browser.version();
+    const screenReaderName = voiceOver.name;
+    const screenReaderVersion = voiceOver.version;
     const { retry } = test.info();
     const recordingFilePath = `./recordings/playwright-voiceOver-textarea-${osName}-${osVersion}-${browserName}-${browserVersion}-attempt-${retry}-${+new Date()}.mov`;
 
@@ -82,6 +88,8 @@ test.describe("Webkit Playwright VoiceOver", () => {
       osVersion,
       browserName,
       browserVersion,
+      screenReaderName,
+      screenReaderVersion,
       retry,
     });
 

--- a/src/IScreenReader.ts
+++ b/src/IScreenReader.ts
@@ -57,6 +57,48 @@ export interface IScreenReader {
   next(options?: CommandOptions): Promise<void>;
 
   /**
+   * Move the screen reader cursor to the previous heading.
+   *
+   * @param {object} [options] Additional options.
+   */
+  previousHeading(options?: CommandOptions): Promise<void>;
+
+  /**
+   * Move the screen reader cursor to the next heading.
+   *
+   * @param {object} [options] Additional options.
+   */
+  nextHeading(options?: CommandOptions): Promise<void>;
+
+  /**
+   * Move the screen reader cursor to the previous link.
+   *
+   * @param {object} [options] Additional options.
+   */
+  previousLink(options?: CommandOptions): Promise<void>;
+
+  /**
+   * Move the screen reader cursor to the next link.
+   *
+   * @param {object} [options] Additional options.
+   */
+  nextLink(options?: CommandOptions): Promise<void>;
+
+  /**
+   * Move the screen reader cursor to the previous landmark.
+   *
+   * @param {object} [options] Additional options.
+   */
+  previousLandmark(options?: CommandOptions): Promise<void>;
+
+  /**
+   * Move the screen reader cursor to the next landmark.
+   *
+   * @param {object} [options] Additional options.
+   */
+  nextLandmark(options?: CommandOptions): Promise<void>;
+
+  /**
    * Perform the default action for the item in the screen reader cursor.
    *
    * @param {object} [options] Additional options.

--- a/src/ScreenReader.ts
+++ b/src/ScreenReader.ts
@@ -95,6 +95,60 @@ export class ScreenReader implements IScreenReader {
   }
 
   /**
+   * Move the screen reader cursor to the previous heading.
+   *
+   * @param {object} [options] Additional options.
+   */
+  previousHeading(options?: CommandOptions): Promise<void> {
+    return this.implementation.previousHeading(options);
+  }
+
+  /**
+   * Move the screen reader cursor to the next heading.
+   *
+   * @param {object} [options] Additional options.
+   */
+  nextHeading(options?: CommandOptions): Promise<void> {
+    return this.implementation.nextHeading(options);
+  }
+
+  /**
+   * Move the screen reader cursor to the previous link.
+   *
+   * @param {object} [options] Additional options.
+   */
+  previousLink(options?: CommandOptions): Promise<void> {
+    return this.implementation.previousLink(options);
+  }
+
+  /**
+   * Move the screen reader cursor to the next link.
+   *
+   * @param {object} [options] Additional options.
+   */
+  nextLink(options?: CommandOptions): Promise<void> {
+    return this.implementation.nextLink(options);
+  }
+
+  /**
+   * Move the screen reader cursor to the previous landmark.
+   *
+   * @param {object} [options] Additional options.
+   */
+  previousLandmark(options?: CommandOptions): Promise<void> {
+    return this.implementation.previousLandmark(options);
+  }
+
+  /**
+   * Move the screen reader cursor to the next landmark.
+   *
+   * @param {object} [options] Additional options.
+   */
+  nextLandmark(options?: CommandOptions): Promise<void> {
+    return this.implementation.nextLandmark(options);
+  }
+
+  /**
    * Perform the default action for the item in the screen reader cursor.
    *
    * @param {object} [options] Additional options.

--- a/src/macOS/VoiceOver/VoiceOver.test.ts
+++ b/src/macOS/VoiceOver/VoiceOver.test.ts
@@ -16,6 +16,7 @@ import { CommanderCommands } from "./CommanderCommands";
 import { delay } from "../../delay";
 import { isKeyboard } from "../../isKeyboard";
 import { isMacOS } from "../isMacOS";
+import { keyCodeCommands } from "./keyCodeCommands";
 import { release } from "node:os";
 import { start } from "./start";
 import { terminateVoiceOverProcess } from "./terminateVoiceOverProcess";
@@ -552,6 +553,204 @@ describe("VoiceOver", () => {
 
       it("should move the cursor to the next item", () => {
         expect(VoiceOverCursorStub.next).toHaveBeenCalledWith(options);
+      });
+    });
+  });
+
+  describe("previousHeading", () => {
+    beforeEach(() => {
+      jest.mocked(isKeyboard).mockReturnValue(true);
+    });
+
+    describe("when VoiceOver is not running", () => {
+      it("should throw an error", async () => {
+        await expect(async () => await vo.previousHeading()).rejects.toThrow(
+          ERR_VOICE_OVER_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe.each`
+      description          | options
+      ${"without options"} | ${undefined}
+      ${"with options"}    | ${{}}
+    `("when called $description", ({ options }) => {
+      beforeEach(async () => {
+        await vo.start();
+        await vo.previousHeading(options);
+        await vo.stop();
+      });
+
+      it("should perform a keyboard command to find the previous heading", () => {
+        expect(VoiceOverKeyboardStub.perform).toHaveBeenCalledWith(
+          keyCodeCommands.findPreviousHeading,
+          options,
+        );
+      });
+    });
+  });
+
+  describe("nextHeading", () => {
+    beforeEach(() => {
+      jest.mocked(isKeyboard).mockReturnValue(true);
+    });
+
+    describe("when VoiceOver is not running", () => {
+      it("should throw an error", async () => {
+        await expect(async () => await vo.nextHeading()).rejects.toThrow(
+          ERR_VOICE_OVER_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe.each`
+      description          | options
+      ${"without options"} | ${undefined}
+      ${"with options"}    | ${{}}
+    `("when called $description", ({ options }) => {
+      beforeEach(async () => {
+        await vo.start();
+        await vo.nextHeading(options);
+        await vo.stop();
+      });
+
+      it("should perform a keyboard command to find the next heading", () => {
+        expect(VoiceOverKeyboardStub.perform).toHaveBeenCalledWith(
+          keyCodeCommands.findNextHeading,
+          options,
+        );
+      });
+    });
+  });
+
+  describe("previousLink", () => {
+    beforeEach(() => {
+      jest.mocked(isKeyboard).mockReturnValue(true);
+    });
+
+    describe("when VoiceOver is not running", () => {
+      it("should throw an error", async () => {
+        await expect(async () => await vo.previousLink()).rejects.toThrow(
+          ERR_VOICE_OVER_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe.each`
+      description          | options
+      ${"without options"} | ${undefined}
+      ${"with options"}    | ${{}}
+    `("when called $description", ({ options }) => {
+      beforeEach(async () => {
+        await vo.start();
+        await vo.previousLink(options);
+        await vo.stop();
+      });
+
+      it("should perform a keyboard command to find the previous link", () => {
+        expect(VoiceOverKeyboardStub.perform).toHaveBeenCalledWith(
+          keyCodeCommands.findPreviousLink,
+          options,
+        );
+      });
+    });
+  });
+
+  describe("nextLink", () => {
+    beforeEach(() => {
+      jest.mocked(isKeyboard).mockReturnValue(true);
+    });
+
+    describe("when VoiceOver is not running", () => {
+      it("should throw an error", async () => {
+        await expect(async () => await vo.nextLink()).rejects.toThrow(
+          ERR_VOICE_OVER_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe.each`
+      description          | options
+      ${"without options"} | ${undefined}
+      ${"with options"}    | ${{}}
+    `("when called $description", ({ options }) => {
+      beforeEach(async () => {
+        await vo.start();
+        await vo.nextLink(options);
+        await vo.stop();
+      });
+
+      it("should perform a keyboard command to find the next link", () => {
+        expect(VoiceOverKeyboardStub.perform).toHaveBeenCalledWith(
+          keyCodeCommands.findNextLink,
+          options,
+        );
+      });
+    });
+  });
+
+  describe("previousLandmark", () => {
+    beforeEach(() => {
+      jest.mocked(isKeyboard).mockReturnValue(true);
+    });
+
+    describe("when VoiceOver is not running", () => {
+      it("should throw an error", async () => {
+        await expect(async () => await vo.previousLandmark()).rejects.toThrow(
+          ERR_VOICE_OVER_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe.each`
+      description          | options
+      ${"without options"} | ${undefined}
+      ${"with options"}    | ${{}}
+    `("when called $description", ({ options }) => {
+      beforeEach(async () => {
+        await vo.start();
+        await vo.previousLandmark(options);
+        await vo.stop();
+      });
+
+      it("should perform a keyboard command to move to the previous landmark", () => {
+        expect(VoiceOverKeyboardStub.perform).toHaveBeenCalledWith(
+          keyCodeCommands.moveToPreviousAutoWebSpot,
+          options,
+        );
+      });
+    });
+  });
+
+  describe("nextLandmark", () => {
+    beforeEach(() => {
+      jest.mocked(isKeyboard).mockReturnValue(true);
+    });
+
+    describe("when VoiceOver is not running", () => {
+      it("should throw an error", async () => {
+        await expect(async () => await vo.nextLandmark()).rejects.toThrow(
+          ERR_VOICE_OVER_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe.each`
+      description          | options
+      ${"without options"} | ${undefined}
+      ${"with options"}    | ${{}}
+    `("when called $description", ({ options }) => {
+      beforeEach(async () => {
+        await vo.start();
+        await vo.nextLandmark(options);
+        await vo.stop();
+      });
+
+      it("should perform a keyboard command to move to the next landmark", () => {
+        expect(VoiceOverKeyboardStub.perform).toHaveBeenCalledWith(
+          keyCodeCommands.moveToNextAutoWebSpot,
+          options,
+        );
       });
     });
   });

--- a/src/macOS/VoiceOver/VoiceOver.ts
+++ b/src/macOS/VoiceOver/VoiceOver.ts
@@ -20,6 +20,7 @@ import { isKeyboard } from "../../isKeyboard";
 import { isMacOS } from "../isMacOS";
 import { KeyboardCommand } from "../KeyboardCommand";
 import { KeyboardOptions } from "../../KeyboardOptions";
+import { keyCodeCommands } from "./keyCodeCommands";
 import type { Prettify } from "../../typeHelpers";
 import { release } from "node:os";
 import { start } from "./start";
@@ -479,6 +480,186 @@ export class VoiceOver implements IScreenReader {
     }
 
     return this.#cursor.next(options);
+  }
+
+  /**
+   * Move the VoiceOver cursor to the previous heading.
+   *
+   * Equivalent of executing `VO-Command-Shift-H`.
+   *
+   * ```ts
+   * import { voiceOver } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start VoiceOver.
+   *   await voiceOver.start();
+   *
+   *   // Move to the previous heading.
+   *   await voiceOver.previousHeading();
+   *
+   *   // Stop VoiceOver.
+   *   await voiceOver.stop();
+   * })();
+   * ```
+   *
+   * @param {object} [options] Additional options.
+   */
+  async previousHeading(options?: CommandOptions): Promise<void> {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
+    }
+
+    return this.perform(keyCodeCommands.findPreviousHeading, options);
+  }
+
+  /**
+   * Move the VoiceOver cursor to the previous heading.
+   *
+   * Equivalent of executing `VO-Command-H`.
+   *
+   * ```ts
+   * import { voiceOver } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start VoiceOver.
+   *   await voiceOver.start();
+   *
+   *   // Move to the next heading.
+   *   await voiceOver.nextHeading();
+   *
+   *   // Stop VoiceOver.
+   *   await voiceOver.stop();
+   * })();
+   * ```
+   *
+   * @param {object} [options] Additional options.
+   */
+  async nextHeading(options?: CommandOptions): Promise<void> {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
+    }
+
+    return this.perform(keyCodeCommands.findNextHeading, options);
+  }
+
+  /**
+   * Move the VoiceOver cursor to the previous link.
+   *
+   * Equivalent of executing `VO-Command-Shift-L`.
+   *
+   * ```ts
+   * import { voiceOver } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start VoiceOver.
+   *   await voiceOver.start();
+   *
+   *   // Move to the previous link.
+   *   await voiceOver.previousLink();
+   *
+   *   // Stop VoiceOver.
+   *   await voiceOver.stop();
+   * })();
+   * ```
+   *
+   * @param {object} [options] Additional options.
+   */
+  async previousLink(options?: CommandOptions): Promise<void> {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
+    }
+
+    return this.perform(keyCodeCommands.findPreviousLink, options);
+  }
+
+  /**
+   * Move the VoiceOver cursor to the previous link.
+   *
+   * Equivalent of executing `VO-Command-L`.
+   *
+   * ```ts
+   * import { voiceOver } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start VoiceOver.
+   *   await voiceOver.start();
+   *
+   *   // Move to the next link.
+   *   await voiceOver.nextLink();
+   *
+   *   // Stop VoiceOver.
+   *   await voiceOver.stop();
+   * })();
+   * ```
+   *
+   * @param {object} [options] Additional options.
+   */
+  async nextLink(options?: CommandOptions): Promise<void> {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
+    }
+
+    return this.perform(keyCodeCommands.findNextLink, options);
+  }
+
+  /**
+   * Move the VoiceOver cursor to the previous landmark.
+   *
+   * Equivalent of executing `VO-Command-Shift-N`.
+   *
+   * ```ts
+   * import { voiceOver } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start VoiceOver.
+   *   await voiceOver.start();
+   *
+   *   // Move to the previous landmark.
+   *   await voiceOver.previousLandmark();
+   *
+   *   // Stop VoiceOver.
+   *   await voiceOver.stop();
+   * })();
+   * ```
+   *
+   * @param {object} [options] Additional options.
+   */
+  async previousLandmark(options?: CommandOptions): Promise<void> {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
+    }
+
+    return this.perform(keyCodeCommands.moveToPreviousAutoWebSpot, options);
+  }
+
+  /**
+   * Move the VoiceOver cursor to the previous landmark.
+   *
+   * Equivalent of executing `VO-Command-N`.
+   *
+   * ```ts
+   * import { voiceOver } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start VoiceOver.
+   *   await voiceOver.start();
+   *
+   *   // Move to the next landmark.
+   *   await voiceOver.nextLandmark();
+   *
+   *   // Stop VoiceOver.
+   *   await voiceOver.stop();
+   * })();
+   * ```
+   *
+   * @param {object} [options] Additional options.
+   */
+  async nextLandmark(options?: CommandOptions): Promise<void> {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
+    }
+
+    return this.perform(keyCodeCommands.moveToNextAutoWebSpot, options);
   }
 
   /**

--- a/src/macOS/VoiceOver/keyCodeCommands.ts
+++ b/src/macOS/VoiceOver/keyCodeCommands.ts
@@ -1,4 +1,5 @@
 // REF: https://www.apple.com/voiceover/info/guide/_1131.html
+// TODO: migrate / fix based on https://help.apple.com/voiceover/command-charts/
 
 import { KeyCodes } from "../KeyCodes";
 import { Modifiers } from "../Modifiers";

--- a/src/windows/NVDA/NVDA.test.ts
+++ b/src/windows/NVDA/NVDA.test.ts
@@ -245,6 +245,186 @@ describe("NVDA", () => {
     });
   });
 
+  describe("previousHeading", () => {
+    beforeEach(() => {
+      nvda = new NVDA();
+    });
+
+    describe("when NVDA is not running", () => {
+      it("should throw an error", async () => {
+        await expect(async () => await nvda.previousHeading()).rejects.toThrow(
+          ERR_NVDA_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe("when NVDA is running", () => {
+      beforeEach(async () => {
+        jest.mocked(start).mockResolvedValue(undefined);
+
+        await nvda.start();
+
+        jest.clearAllMocks();
+
+        await nvda.previousHeading();
+      });
+
+      it("should enqueue a key press command", () => {
+        expect(NVDAClientStub.enqueueAndTap).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("nextHeading", () => {
+    beforeEach(() => {
+      nvda = new NVDA();
+    });
+
+    describe("when NVDA is not running", () => {
+      it("should throw an error", async () => {
+        await expect(async () => await nvda.nextHeading()).rejects.toThrow(
+          ERR_NVDA_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe("when NVDA is running", () => {
+      beforeEach(async () => {
+        jest.mocked(start).mockResolvedValue(undefined);
+
+        await nvda.start();
+
+        jest.clearAllMocks();
+
+        await nvda.nextHeading();
+      });
+
+      it("should enqueue a key press command", () => {
+        expect(NVDAClientStub.enqueueAndTap).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("previousLink", () => {
+    beforeEach(() => {
+      nvda = new NVDA();
+    });
+
+    describe("when NVDA is not running", () => {
+      it("should throw an error", async () => {
+        await expect(async () => await nvda.previousLink()).rejects.toThrow(
+          ERR_NVDA_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe("when NVDA is running", () => {
+      beforeEach(async () => {
+        jest.mocked(start).mockResolvedValue(undefined);
+
+        await nvda.start();
+
+        jest.clearAllMocks();
+
+        await nvda.previousLink();
+      });
+
+      it("should enqueue a key press command", () => {
+        expect(NVDAClientStub.enqueueAndTap).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("nextLink", () => {
+    beforeEach(() => {
+      nvda = new NVDA();
+    });
+
+    describe("when NVDA is not running", () => {
+      it("should throw an error", async () => {
+        await expect(async () => await nvda.nextLink()).rejects.toThrow(
+          ERR_NVDA_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe("when NVDA is running", () => {
+      beforeEach(async () => {
+        jest.mocked(start).mockResolvedValue(undefined);
+
+        await nvda.start();
+
+        jest.clearAllMocks();
+
+        await nvda.nextLink();
+      });
+
+      it("should enqueue a key press command", () => {
+        expect(NVDAClientStub.enqueueAndTap).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("previousLandmark", () => {
+    beforeEach(() => {
+      nvda = new NVDA();
+    });
+
+    describe("when NVDA is not running", () => {
+      it("should throw an error", async () => {
+        await expect(async () => await nvda.previousLandmark()).rejects.toThrow(
+          ERR_NVDA_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe("when NVDA is running", () => {
+      beforeEach(async () => {
+        jest.mocked(start).mockResolvedValue(undefined);
+
+        await nvda.start();
+
+        jest.clearAllMocks();
+
+        await nvda.previousLandmark();
+      });
+
+      it("should enqueue a key press command", () => {
+        expect(NVDAClientStub.enqueueAndTap).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("nextLandmark", () => {
+    beforeEach(() => {
+      nvda = new NVDA();
+    });
+
+    describe("when NVDA is not running", () => {
+      it("should throw an error", async () => {
+        await expect(async () => await nvda.nextLandmark()).rejects.toThrow(
+          ERR_NVDA_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe("when NVDA is running", () => {
+      beforeEach(async () => {
+        jest.mocked(start).mockResolvedValue(undefined);
+
+        await nvda.start();
+
+        jest.clearAllMocks();
+
+        await nvda.nextLandmark();
+      });
+
+      it("should enqueue a key press command", () => {
+        expect(NVDAClientStub.enqueueAndTap).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe("spokenPhraseLog", () => {
     beforeEach(() => {
       nvda = new NVDA();

--- a/src/windows/NVDA/NVDA.ts
+++ b/src/windows/NVDA/NVDA.ts
@@ -365,6 +365,186 @@ export class NVDA implements IScreenReader {
   }
 
   /**
+   * Move the NVDA cursor to the previous heading.
+   *
+   * Equivalent of executing `Shift-H`.
+   *
+   * ```ts
+   * import { nvda } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start NVDA.
+   *   await nvda.start();
+   *
+   *   // Move to the previous heading.
+   *   await nvda.previousHeading();
+   *
+   *   // Stop NVDA.
+   *   await nvda.stop();
+   * })();
+   * ```
+   *
+   * @param {object} [options] Additional options.
+   */
+  async previousHeading(options?: CommandOptions): Promise<void> {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_NVDA_NOT_RUNNING);
+    }
+
+    return this.perform(this.keyboardCommands.moveToPreviousHeading, options);
+  }
+
+  /**
+   * Move the NVDA cursor to the previous heading.
+   *
+   * Equivalent of executing `H`.
+   *
+   * ```ts
+   * import { nvda } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start NVDA.
+   *   await nvda.start();
+   *
+   *   // Move to the next heading.
+   *   await nvda.nextHeading();
+   *
+   *   // Stop NVDA.
+   *   await nvda.stop();
+   * })();
+   * ```
+   *
+   * @param {object} [options] Additional options.
+   */
+  async nextHeading(options?: CommandOptions): Promise<void> {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_NVDA_NOT_RUNNING);
+    }
+
+    return this.perform(this.keyboardCommands.moveToNextHeading, options);
+  }
+
+  /**
+   * Move the NVDA cursor to the previous link.
+   *
+   * Equivalent of executing `Shift-K`.
+   *
+   * ```ts
+   * import { nvda } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start NVDA.
+   *   await nvda.start();
+   *
+   *   // Move to the previous link.
+   *   await nvda.previousLink();
+   *
+   *   // Stop NVDA.
+   *   await nvda.stop();
+   * })();
+   * ```
+   *
+   * @param {object} [options] Additional options.
+   */
+  async previousLink(options?: CommandOptions): Promise<void> {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_NVDA_NOT_RUNNING);
+    }
+
+    return this.perform(this.keyboardCommands.moveToNextLink, options);
+  }
+
+  /**
+   * Move the NVDA cursor to the previous link.
+   *
+   * Equivalent of executing `K`.
+   *
+   * ```ts
+   * import { nvda } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start NVDA.
+   *   await nvda.start();
+   *
+   *   // Move to the next link.
+   *   await nvda.nextLink();
+   *
+   *   // Stop NVDA.
+   *   await nvda.stop();
+   * })();
+   * ```
+   *
+   * @param {object} [options] Additional options.
+   */
+  async nextLink(options?: CommandOptions): Promise<void> {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_NVDA_NOT_RUNNING);
+    }
+
+    return this.perform(this.keyboardCommands.moveToPreviousLink, options);
+  }
+
+  /**
+   * Move the NVDA cursor to the previous landmark.
+   *
+   * Equivalent of executing `Shift-D`.
+   *
+   * ```ts
+   * import { nvda } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start NVDA.
+   *   await nvda.start();
+   *
+   *   // Move to the previous landmark.
+   *   await nvda.previousLandmark();
+   *
+   *   // Stop NVDA.
+   *   await nvda.stop();
+   * })();
+   * ```
+   *
+   * @param {object} [options] Additional options.
+   */
+  async previousLandmark(options?: CommandOptions): Promise<void> {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_NVDA_NOT_RUNNING);
+    }
+
+    return this.perform(this.keyboardCommands.moveToPreviousLandmark, options);
+  }
+
+  /**
+   * Move the NVDA cursor to the previous landmark.
+   *
+   * Equivalent of executing `D`.
+   *
+   * ```ts
+   * import { nvda } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start NVDA.
+   *   await nvda.start();
+   *
+   *   // Move to the next landmark.
+   *   await nvda.nextLandmark();
+   *
+   *   // Stop NVDA.
+   *   await nvda.stop();
+   * })();
+   * ```
+   *
+   * @param {object} [options] Additional options.
+   */
+  async nextLandmark(options?: CommandOptions): Promise<void> {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_NVDA_NOT_RUNNING);
+    }
+
+    return this.perform(this.keyboardCommands.moveToNextLandmark, options);
+  }
+
+  /**
    * Perform the default action for the item in the NVDA cursor.
    *
    * Equivalent of executing `Enter`.


### PR DESCRIPTION
# Issue

Fixes #124 

## Details

Introduces the following 6 methods:

- `previousHeading([options])`
- `nextHeading([options])`
- `previousLink([options])`
- `nextLink([options])`
- `previousLandmark([options])`
- `nextLandmark([options])`

These are available on the `screenReader`, `nvda`, and `voiceOver` instances.

## CheckList

- [x] Has been tested (where required).