### PR TITLE
feat: capture command for 3rd party integration

### DIFF
--- a/.github/workflows/playwright-nvda.yml
+++ b/.github/workflows/playwright-nvda.yml
@@ -24,7 +24,6 @@ jobs:
           node-version-file: .nvmrc
       - run: npx -y @guidepup/setup@0.24.1 setup --ci
       - run: npm ci --no-audit --no-fund --no-progress
-      - run: npm run build
       - run: npm ci --prefix ./examples/playwright-nvda --no-audit --no-fund --no-progress
       - run: npm --prefix ./examples/playwright-nvda rebuild ffmpeg-static --ignore-scripts=false
       - run: npx -y @guidepup/setup@0.24.1 install

--- a/.github/workflows/playwright-screenreader.yml
+++ b/.github/workflows/playwright-screenreader.yml
@@ -24,7 +24,6 @@ jobs:
           node-version-file: .nvmrc
       - run: npx -y @guidepup/setup@0.24.1 setup --ci --macos-record
       - run: npm ci --no-audit --no-fund --no-progress
-      - run: npm run build
       - run: npm ci --prefix ./examples/playwright-screenreader --no-audit --no-fund --no-progress
       - run: npm --prefix ./examples/playwright-screenreader rebuild ffmpeg-static --ignore-scripts=false
       - run: npm --prefix ./examples/playwright-screenreader run browsers

--- a/.github/workflows/playwright-voiceover.yml
+++ b/.github/workflows/playwright-voiceover.yml
@@ -24,7 +24,6 @@ jobs:
           node-version-file: .nvmrc
       - run: npx -y @guidepup/setup@0.24.1 setup --ci --macos-record
       - run: npm ci --no-audit --no-fund --no-progress
-      - run: npm run build
       - run: npm ci --prefix ./examples/playwright-voiceover --no-audit --no-fund --no-progress
       - run: npm --prefix ./examples/playwright-voiceover rebuild ffmpeg-static --ignore-scripts=false
       - run: npm --prefix ./examples/playwright-voiceover run browsers

--- a/examples/applicationNameMap.ts
+++ b/examples/applicationNameMap.ts
@@ -1,0 +1,10 @@
+export const applicationNameMap = {
+  chromium: "Google Chrome For Testing",
+  chrome: "Google Chrome",
+  "chrome-beta": "Google Chrome Beta",
+  msedge: "Microsoft Edge",
+  "msedge-beta": "Microsoft Edge Beta",
+  "msedge-dev": "Microsoft Edge Dev",
+  firefox: "Nightly",
+  webkit: "Playwright",
+};

--- a/examples/playwright-nvda/nvda-test.ts
+++ b/examples/playwright-nvda/nvda-test.ts
@@ -1,19 +1,47 @@
-import { NVDA, nvda, WindowsKeyCodes, WindowsModifiers } from "../../lib";
+import { NVDA, nvda, WindowsKeyCodes, WindowsModifiers } from "../../src";
+import { applicationNameMap } from "../applicationNameMap";
+import type { CommandOptions } from "../../src";
+import { delay } from "../../src/delay";
+import type { StartOptions } from "../../src/StartOptions";
 import { test } from "@playwright/test";
 
-export const applicationNameMap = {
-  chromium: "Google Chrome For Testing",
-  chrome: "Google Chrome",
-  "chrome-beta": "Google Chrome Beta",
-  msedge: "Microsoft Edge",
-  "msedge-beta": "Microsoft Edge Beta",
-  "msedge-dev": "Microsoft Edge Dev",
-  firefox: "Nightly",
-  webkit: "Playwright",
-};
+type Prettify<T> = {
+  [K in keyof T]: T[K];
+} & {};
 
+type CaptureCommandOptions = Prettify<Pick<CommandOptions, "capture">>;
+type CaptureStartOptions = Prettify<Pick<StartOptions, "capture" | "settings">>;
+
+/**
+ * [API Reference](https://www.guidepup.dev/docs/api/class-nvda)
+ *
+ * This object can be used to launch and control NVDA.
+ *
+ * Here's a typical example:
+ *
+ * ```ts
+ * import { nvda } from "@guidepup/guidepup";
+ *
+ * (async () => {
+ *   // Start NVDA.
+ *   await nvda.start();
+ *
+ *   // Move to the next item.
+ *   await nvda.next();
+ *
+ *   // Stop NVDA.
+ *   await nvda.stop();
+ * })();
+ * ```
+ */
 export interface NVDAPlaywright extends NVDA {
-  navigateToWebContent(): Promise<void>;
+  /**
+   * Guidepup Playwright specific command that navigates NVDA to the beginning
+   * of the browser's web content.
+   *
+   * This command should be used after page navigation.
+   */
+  navigateToWebContent(options?: CaptureCommandOptions): Promise<void>;
 }
 
 const nvdaPlaywright: NVDAPlaywright = nvda as NVDAPlaywright;
@@ -78,7 +106,9 @@ const focusBrowser = async ({
   while (applicationSwitchRetryCount < MAX_APPLICATION_SWITCH_RETRY_COUNT) {
     applicationSwitchRetryCount++;
 
-    await nvdaPlaywright.perform(SWITCH_APPLICATION);
+    await nvdaPlaywright.perform(SWITCH_APPLICATION, { capture: false });
+    await delay(500);
+
     await nvdaPlaywright.perform(nvdaPlaywright.keyboardCommands.reportTitle);
     windowTitle = await nvdaPlaywright.lastSpokenPhrase();
 
@@ -94,8 +124,39 @@ const focusBrowser = async ({
  *
  * A fresh started NVDA instance `nvda` is provided to each test.
  */
-const nvdaTest = test.extend<{ nvda: NVDAPlaywright }>({
-  nvda: async ({ browserName, page }, use) => {
+export const nvdaTest = test.extend<{
+  /**
+   * [API Reference](https://www.guidepup.dev/docs/api/class-nvda)
+   *
+   * This object can be used to launch and control NVDA.
+   *
+   * Here's a typical example:
+   *
+   * ```ts
+   * import { nvda } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start NVDA.
+   *   await nvda.start();
+   *
+   *   // Move to the next item.
+   *   await nvda.next();
+   *
+   *   // Stop NVDA.
+   *   await nvda.stop();
+   * })();
+   * ```
+   */
+  nvda: NVDAPlaywright;
+  /**
+   * [API Reference](https://www.guidepup.dev/docs/api/class-command-options)
+   *
+   * Options to start NVDA with, see also [nvda.start([options])](https://www.guidepup.dev/docs/api/class-nvda#nvda-start).
+   */
+  nvdaStartOptions: CaptureStartOptions;
+}>({
+  nvdaStartOptions: { capture: "initial" },
+  nvda: async ({ browserName, page, nvdaStartOptions }, use) => {
     try {
       const applicationName = applicationNameMap[browserName];
 
@@ -103,66 +164,83 @@ const nvdaTest = test.extend<{ nvda: NVDAPlaywright }>({
         throw new Error(`Browser ${browserName} is not installed.`);
       }
 
-      nvdaPlaywright.navigateToWebContent = async () => {
+      nvdaPlaywright.navigateToWebContent = async ({ capture } = {}) => {
+        const currentSpokenPhraseLog = [
+          ...(await nvdaPlaywright.spokenPhraseLog()),
+        ];
+        const currentItemTextLog = [...(await nvdaPlaywright.itemTextLog())];
+
+        // Make sure NVDA is not in focus mode.
         await nvdaPlaywright.perform(
           nvdaPlaywright.keyboardCommands.exitFocusMode,
+          { capture: false },
         );
+        await delay(100);
 
+        // Ensure application is brought to front and focused.
         const pageTitle = await page.title();
         await focusBrowser({ applicationName, pageTitle });
 
+        // Ensure the document is ready and focused.
         await page.bringToFront();
         await page.locator("body").waitFor();
         await page.locator("body").focus();
         await page.locator("body").click();
+        await page.locator("body").blur();
 
+        // NVDA appears to not work well with Firefox when switching between
+        // applications resulting in the entire browser window having NVDA focus
+        // with focus mode.
+        //
+        // One workaround is to tab to the next focusable item. From there we can
+        // toggle into (yes although we are already in it...) focus mode and back
+        // out. In case this ever transpires to not happen as expect, we then ensure
+        // we exit focus mode and move NVDA to the top of the page.
+        //
+        // REF: https://github.com/nvaccess/nvda/issues/5758
         await nvdaPlaywright.perform(
           nvdaPlaywright.keyboardCommands.readNextFocusableItem,
+          { capture: false },
         );
+        await delay(100);
         await nvdaPlaywright.perform(
           nvdaPlaywright.keyboardCommands.toggleBetweenBrowseAndFocusMode,
+          { capture: false },
         );
+        await delay(100);
         await nvdaPlaywright.perform(
           nvdaPlaywright.keyboardCommands.toggleBetweenBrowseAndFocusMode,
+          { capture: false },
         );
+        await delay(100);
         await nvdaPlaywright.perform(
           nvdaPlaywright.keyboardCommands.exitFocusMode,
+          { capture: false },
         );
-        await nvdaPlaywright.perform(MOVE_TO_TOP);
+        await delay(100);
 
-        await nvdaPlaywright.clearItemTextLog();
         await nvdaPlaywright.clearSpokenPhraseLog();
+        await nvdaPlaywright.clearItemTextLog();
+
+        const spokenPhraseLog = await nvdaPlaywright.spokenPhraseLog();
+        const itemTextLog = await nvdaPlaywright.itemTextLog();
+
+        spokenPhraseLog.push(...currentSpokenPhraseLog);
+        itemTextLog.push(...currentItemTextLog);
+
+        // Navigate to the beginning of the web content, using chosen capture
+        // settings, so don't miss announcing the first item on the page.
+        await nvdaPlaywright.perform(MOVE_TO_TOP, { capture });
       };
 
-      await nvdaPlaywright.start({
-        capture: "initial",
-        settings: {
-          speech: {
-            oneCore: {
-              voice:
-                "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Speech_OneCore\\Voices\\Tokens\\MSTTS_V110_enGB_SusanM",
-            },
-          },
-          vision: {
-            NVDAHighlighter: {
-              highlightFocus: false,
-              highlightNavigator: false,
-              highlightBrowseMode: false,
-              enabled: false,
-            },
-          },
-        },
-      });
-
+      await nvdaPlaywright.start(nvdaStartOptions);
       await use(nvdaPlaywright);
     } finally {
       try {
-        await nvda.stop();
+        await nvdaPlaywright.stop();
       } catch {
         // swallow stop failure
       }
     }
   },
 });
-
-export { nvdaTest };

--- a/examples/playwright-nvda/tests/chromium/chromium.spec.ts
+++ b/examples/playwright-nvda/tests/chromium/chromium.spec.ts
@@ -1,5 +1,5 @@
 import { platform, release } from "os";
-import { delay } from "../delay";
+import { delay } from "../../../../src/delay";
 import { expect } from "@playwright/test";
 import { headerNavigation } from "../headerNavigation";
 import { log } from "../../../log";
@@ -19,6 +19,28 @@ const record = async (filepath: string) => {
     );
   }
 };
+
+test.use({
+  nvdaStartOptions: {
+    capture: "initial",
+    settings: {
+      speech: {
+        oneCore: {
+          voice:
+            "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Speech_OneCore\\Voices\\Tokens\\MSTTS_V110_enGB_SusanM",
+        },
+      },
+      vision: {
+        NVDAHighlighter: {
+          highlightFocus: false,
+          highlightNavigator: false,
+          highlightBrowseMode: false,
+          enabled: false,
+        },
+      },
+    },
+  },
+});
 
 test.describe("Chromium Playwright NVDA", () => {
   test("I can navigate the Guidepup Github page", async ({

--- a/examples/playwright-nvda/tests/delay.ts
+++ b/examples/playwright-nvda/tests/delay.ts
@@ -1,3 +1,0 @@
-export async function delay(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}

--- a/examples/playwright-nvda/tests/headerNavigation.ts
+++ b/examples/playwright-nvda/tests/headerNavigation.ts
@@ -1,4 +1,4 @@
-import { delay } from "./delay";
+import { delay } from "../../../src/delay";
 import { log } from "../../log";
 import { NVDAPlaywright } from "../nvda-test";
 import { Page } from "@playwright/test";

--- a/examples/playwright-screenreader/screenreader-test.ts
+++ b/examples/playwright-screenreader/screenreader-test.ts
@@ -1,3 +1,4 @@
+import type { CommandOptions, ScreenReader } from "../../src";
 import {
   macOSActivate,
   MacOSKeyCodes,
@@ -9,19 +10,17 @@ import {
   WindowsKeyCodes,
   WindowsModifiers,
 } from "../../src";
-import type { ScreenReader } from "../../src";
+import { applicationNameMap } from "../applicationNameMap";
+import { delay } from "../../src/delay";
+import type { StartOptions } from "../../src/StartOptions";
 import { test } from "@playwright/test";
 
-const applicationNameMap = {
-  chromium: "Google Chrome For Testing",
-  chrome: "Google Chrome",
-  "chrome-beta": "Google Chrome Beta",
-  msedge: "Microsoft Edge",
-  "msedge-beta": "Microsoft Edge Beta",
-  "msedge-dev": "Microsoft Edge Dev",
-  firefox: "Nightly",
-  webkit: "Playwright",
-};
+type Prettify<T> = {
+  [K in keyof T]: T[K];
+} & {};
+
+type CaptureCommandOptions = Prettify<Pick<CommandOptions, "capture">>;
+type CaptureStartOptions = Prettify<Pick<StartOptions, "capture" | "settings">>;
 
 const MAX_APPLICATION_SWITCH_RETRY_COUNT = 10;
 
@@ -83,7 +82,11 @@ const focusBrowser = async ({
   while (applicationSwitchRetryCount < MAX_APPLICATION_SWITCH_RETRY_COUNT) {
     applicationSwitchRetryCount++;
 
-    await screenReaderPlaywright.perform(SWITCH_APPLICATION);
+    await screenReaderPlaywright.perform(SWITCH_APPLICATION, {
+      capture: false,
+    });
+    await delay(500);
+
     await screenReaderPlaywright.perform(NVDAKeyCodeCommands.reportTitle);
     windowTitle = await screenReaderPlaywright.lastSpokenPhrase();
 
@@ -93,16 +96,37 @@ const focusBrowser = async ({
   }
 };
 
+/**
+ * This object can be used to launch and control the default screen reader for
+ * the environment.
+ *
+ * Here's a typical example:
+ *
+ * ```ts
+ * import { screenReader } from "@guidepup/guidepup";
+ *
+ * (async () => {
+ *   // Start the screen reader.
+ *   await screenReader.start();
+ *
+ *   // Move to the next item.
+ *   await screenReader.next();
+ *
+ *   // ... perform some commands.
+ *
+ *   // Stop the screen reader.
+ *   await screenReader.stop();
+ * })();
+ * ```
+ */
 export interface ScreenReaderPlaywright extends ScreenReader {
   /**
    * Guidepup Playwright specific command that navigates the screen reader to
    * the beginning of the browser's web content.
    *
    * This command should be used after page navigation.
-   *
-   * Note: this command clears all logs.
    */
-  navigateToWebContent(): Promise<void>;
+  navigateToWebContent(options?: CaptureCommandOptions): Promise<void>;
 }
 
 const screenReaderPlaywright: ScreenReaderPlaywright =
@@ -116,8 +140,41 @@ const screenReaderPlaywright: ScreenReaderPlaywright =
  * A fresh started screen reader instance `screenReader` is provided to each
  * test.
  */
-const srTest = test.extend<{ screenReader: ScreenReaderPlaywright }>({
-  screenReader: async ({ browserName, page }, use) => {
+export const screenReaderTest = test.extend<{
+  /**
+   * This object can be used to launch and control the default screen reader for
+   * the environment.
+   *
+   * Here's a typical example:
+   *
+   * ```ts
+   * import { screenReader } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start the screen reader.
+   *   await screenReader.start();
+   *
+   *   // Move to the next item.
+   *   await screenReader.next();
+   *
+   *   // ... perform some commands.
+   *
+   *   // Stop the screen reader.
+   *   await screenReader.stop();
+   * })();
+   * ```
+   */
+  screenReader: ScreenReaderPlaywright;
+  /**
+   * Options to start the default screen reader with.
+   */
+  screenReaderStartOptions: CaptureStartOptions;
+}>({
+  screenReaderStartOptions: { capture: "initial" },
+  screenReader: async (
+    { browserName, page, screenReaderStartOptions },
+    use,
+  ) => {
     try {
       const applicationName = applicationNameMap[browserName];
 
@@ -126,80 +183,190 @@ const srTest = test.extend<{ screenReader: ScreenReaderPlaywright }>({
       }
 
       if (nvda.default()) {
-        screenReaderPlaywright.navigateToWebContent = async () => {
+        screenReaderPlaywright.navigateToWebContent = async ({
+          capture,
+        } = {}) => {
+          const currentSpokenPhraseLog = [
+            ...(await screenReaderPlaywright.spokenPhraseLog()),
+          ];
+          const currentItemTextLog = [
+            ...(await screenReaderPlaywright.itemTextLog()),
+          ];
+
+          // Make sure NVDA is not in focus mode.
           await screenReaderPlaywright.perform(
             NVDAKeyCodeCommands.exitFocusMode,
+            { capture: false },
           );
+          await delay(100);
 
+          // Ensure application is brought to front and focused.
           const pageTitle = await page.title();
           await focusBrowser({ applicationName, pageTitle });
 
+          // Ensure the document is ready and focused.
           await page.bringToFront();
           await page.locator("body").waitFor();
           await page.locator("body").focus();
           await page.locator("body").click();
+          await page.locator("body").blur();
 
+          // NVDA appears to not work well with Firefox when switching between
+          // applications resulting in the entire browser window having NVDA focus
+          // with focus mode.
+          //
+          // One workaround is to tab to the next focusable item. From there we can
+          // toggle into (yes although we are already in it...) focus mode and back
+          // out. In case this ever transpires to not happen as expect, we then ensure
+          // we exit focus mode and move NVDA to the top of the page.
+          //
+          // REF: https://github.com/nvaccess/nvda/issues/5758
           await screenReaderPlaywright.perform(
             NVDAKeyCodeCommands.readNextFocusableItem,
+            { capture: false },
           );
+          await delay(100);
           await screenReaderPlaywright.perform(
             NVDAKeyCodeCommands.toggleBetweenBrowseAndFocusMode,
+            { capture: false },
           );
+          await delay(100);
           await screenReaderPlaywright.perform(
             NVDAKeyCodeCommands.toggleBetweenBrowseAndFocusMode,
+            { capture: false },
           );
+          await delay(100);
           await screenReaderPlaywright.perform(
             NVDAKeyCodeCommands.exitFocusMode,
+            { capture: false },
           );
-          await screenReaderPlaywright.perform(MOVE_TO_TOP);
+          await delay(100);
 
-          await screenReaderPlaywright.clearItemTextLog();
           await screenReaderPlaywright.clearSpokenPhraseLog();
+          await screenReaderPlaywright.clearItemTextLog();
+
+          const spokenPhraseLog =
+            await screenReaderPlaywright.spokenPhraseLog();
+          const itemTextLog = await screenReaderPlaywright.itemTextLog();
+
+          spokenPhraseLog.push(...currentSpokenPhraseLog);
+          itemTextLog.push(...currentItemTextLog);
+
+          // Navigate to the beginning of the web content, using chosen capture
+          // settings, so don't miss announcing the first item on the page.
+          await screenReaderPlaywright.perform(MOVE_TO_TOP, { capture });
         };
       } else if (voiceOver.default()) {
-        screenReaderPlaywright.navigateToWebContent = async (
-          clearLogs: boolean = true,
-        ) => {
+        screenReaderPlaywright.navigateToWebContent = async ({
+          capture,
+        } = {}) => {
+          // Ensure application is brought to front and focused.
           await macOSActivate(applicationName);
 
-          await screenReaderPlaywright.perform({
-            keyCode: MacOSKeyCodes.Control,
-          });
+          // Cancel auto navigation.
+          await screenReaderPlaywright.perform(
+            { keyCode: MacOSKeyCodes.Control },
+            { capture: false },
+          );
+          await delay(100);
 
+          // Ensure the document is ready and focused.
           await page.bringToFront();
           await page.locator("body").waitFor();
 
-          await screenReaderPlaywright.perform(
-            voiceOverKeyCodeCommands.openItemChooser,
-          );
+          try {
+            // Add an interactive marker to the page that will force VoiceOver
+            // to listen to events emitted by Playwright interactions when
+            // navigated to.
+            await page.evaluate(() => {
+              const marker = document.createElement("input");
 
-          await screenReaderPlaywright.type("web content");
+              marker.id = "__guidepup_marker__";
+              marker.type = "text";
+              marker.value = "Guidepup Marker";
+              marker.readOnly = true;
+              marker.tabIndex = -1;
+              marker.autocomplete = "off";
+              marker.setAttribute("aria-label", "Guidepup Marker");
+              marker.style.cssText = `
+              position: absolute;
+              width: 1px;
+              height: 1px;
+              overflow: hidden;
+              clip: rect(0 0 0 0);
+              white-space: nowrap;
+            `;
 
-          await screenReaderPlaywright.perform({
-            keyCode: MacOSKeyCodes.Enter,
-          });
+              document.body.prepend(marker);
+            });
 
-          await screenReaderPlaywright.interact();
+            // Open the web item chooser.
+            await screenReaderPlaywright.perform(
+              voiceOverKeyCodeCommands.openItemChooser,
+              { capture: false },
+            );
+            await delay(500);
 
-          await screenReaderPlaywright.perform(
-            voiceOverKeyCodeCommands.moveToBeginningOfText,
-          );
+            // Filter by "web content" - currently web content items for all browsers
+            // are suffixed by "web content".
+            for (const character of "web content") {
+              await screenReaderPlaywright.type(character, { capture: false });
+              await delay(100);
+            }
 
-          await screenReaderPlaywright.perform({
-            keyCode: MacOSKeyCodes.Control,
-          });
+            // Select the web content window spot.
+            await screenReaderPlaywright.perform(
+              { keyCode: MacOSKeyCodes.Enter },
+              { capture: false },
+            );
+            await delay(100);
 
-          if (clearLogs) {
-            await screenReaderPlaywright.clearItemTextLog();
-            await screenReaderPlaywright.clearSpokenPhraseLog();
+            // Navigate into web content.
+            await screenReaderPlaywright.interact({ capture: false });
+            await delay(100);
+
+            // Navigate to the beginning of the web content.
+            await screenReaderPlaywright.perform(
+              voiceOverKeyCodeCommands.moveToBeginningOfText,
+              { capture: false },
+            );
+            await delay(100);
+
+            // Cancel auto navigation
+            await screenReaderPlaywright.perform(
+              { keyCode: MacOSKeyCodes.Control },
+              { capture: false },
+            );
+            await delay(100);
+
+            // Navigate to the Guidepup marker element at beginning of the web
+            // content.
+            await screenReaderPlaywright.perform(
+              voiceOverKeyCodeCommands.moveToBeginningOfText,
+              { capture: false },
+            );
+            await delay(100);
+
+            // Navigate to the first element of the page using the provided
+            // capture settings.
+            await screenReaderPlaywright.next({ capture });
+          } finally {
+            // Remove the temporary Guidepup marker element to restore original
+            // page structure.
+            await page.evaluate(() => {
+              const marker = document.querySelector("#__guidepup_marker__");
+
+              if (marker) {
+                document.body.removeChild(marker);
+              }
+            });
           }
         };
       } else {
         throw new Error("No supported screen reader");
       }
 
-      await screenReaderPlaywright.start({ capture: "initial" });
-
+      await screenReaderPlaywright.start(screenReaderStartOptions);
       await use(screenReaderPlaywright);
     } finally {
       try {
@@ -210,5 +377,3 @@ const srTest = test.extend<{ screenReader: ScreenReaderPlaywright }>({
     }
   },
 });
-
-export { srTest };

--- a/examples/playwright-screenreader/tests/chromium/chromium-live-region.spec.ts
+++ b/examples/playwright-screenreader/tests/chromium/chromium-live-region.spec.ts
@@ -1,0 +1,78 @@
+import { platform, release } from "os";
+import { expect } from "@playwright/test";
+import { log } from "../../../log";
+import { screenReaderTest as test } from "../../screenreader-test";
+
+test.describe("Chromium Playwright Screen Reader", () => {
+  test("I can capture screen reader output from Playwright commands", async ({
+    browser,
+    browserName,
+    page,
+    screenReader,
+  }) => {
+    const osName = platform();
+    const osVersion = release();
+    const browserVersion = browser.version();
+    const screenReaderName = screenReader.name;
+    const screenReaderVersion = screenReader.version;
+    const { retry } = test.info();
+
+    console.table({
+      osName,
+      osVersion,
+      browserName,
+      browserVersion,
+      screenReaderName,
+      screenReaderVersion,
+      retry,
+    });
+
+    log("Navigating to live region test page.");
+
+    await page.goto("about:blank", {
+      waitUntil: "load",
+    });
+
+    await page.setContent(`
+      <main>
+        <h1>Example 1</h1>
+        <button id="trigger">Update</button>
+      </main>
+
+      <div role="alert" id="live"></div>
+
+      <script>
+        document.querySelector("#trigger").addEventListener("click", () => {
+          document.querySelector("#live").textContent = "testing testing 123"
+        });
+      </script>
+    `);
+
+    const button = page.locator("#trigger");
+    await button.waitFor();
+    await screenReader.navigateToWebContent();
+
+    log(`Performing capture: Playwright focus`);
+    const { spokenPhrase: focusSpokenPhrase } = await screenReader.capture(() =>
+      button.focus(),
+    );
+    log(`Screen reader output: "${focusSpokenPhrase}".`);
+
+    log(`Performing capture: Playwright click`);
+    const { spokenPhrase: clickSpokenPhrase } = await screenReader.capture(
+      () => button.click(),
+      {
+        // Capture full output as there is potential for multiple phrases:
+        //
+        // 1. The button itself
+        // 2. And the live region announcement
+        //
+        // And the default capture of "initial" will cut off the announcement.
+        capture: true,
+      },
+    );
+    log(`Screen reader output: "${clickSpokenPhrase}".`);
+
+    expect(clickSpokenPhrase).toContain("testing testing 123");
+  });
+});

--- a/examples/playwright-screenreader/tests/chromium/chromium-live-region.spec.ts
+++ b/examples/playwright-screenreader/tests/chromium/chromium-live-region.spec.ts
@@ -1,4 +1,5 @@
 import { platform, release } from "os";
+import { delay } from "../../../../src/delay";
 import { expect } from "@playwright/test";
 import { log } from "../../../log";
 import { screenReaderTest as test } from "../../screenreader-test";
@@ -50,7 +51,10 @@ test.describe("Chromium Playwright Screen Reader", () => {
 
     const button = page.locator("#trigger");
     await button.waitFor();
+    await delay(500);
+
     await screenReader.navigateToWebContent();
+    await delay(500);
 
     log(`Performing capture: Playwright focus`);
     const { spokenPhrase: focusSpokenPhrase } = await screenReader.capture(() =>

--- a/examples/playwright-screenreader/tests/chromium/chromium.spec.ts
+++ b/examples/playwright-screenreader/tests/chromium/chromium.spec.ts
@@ -1,10 +1,10 @@
 import { platform, release } from "os";
-import { delay } from "../delay";
+import { expect } from "@playwright/test";
 import { headerNavigation } from "../headerNavigation";
 import { log } from "../../../log";
 import { logIncludesExpectedPhrases } from "../../../logIncludesExpectedPhrases";
 import spokenPhraseSnapshot from "./chromium.spokenPhrase.snapshot.json";
-import { srTest as test } from "../../screenreader-test";
+import { screenReaderTest as test } from "../../screenreader-test";
 
 test.describe("Chromium Playwright Screen Reader", () => {
   test("I can navigate the Guidepup Github page", async ({
@@ -68,6 +68,7 @@ test.describe("Chromium Playwright Screen Reader", () => {
     });
 
     log("Navigating to live region test page.");
+
     await page.goto("about:blank", {
       waitUntil: "load",
     });
@@ -84,37 +85,17 @@ test.describe("Chromium Playwright Screen Reader", () => {
         document.querySelector("#trigger").addEventListener("click", () => {
           document.querySelector("#live").textContent = "testing testing 123"
         });
-
-        setInterval(() => {
-          document.querySelector("#live").textContent = Math.random();
-        }, 2000);
       </script>
     `);
 
     const button = page.locator("#trigger");
     await button.waitFor();
-    await delay(500);
-
     await screenReader.navigateToWebContent();
 
-    console.log(
-      await screenReader.capture(() =>
-        page.evaluate(() => {
-          document.querySelector("#live")!.textContent = "Playwright overwrite";
-        }),
-      ),
-    );
+    log(`Performing capture: Playwright click`);
+    const { spokenPhrase } = await screenReader.capture(() => button.click());
+    log(`Screen reader output: "${spokenPhrase}".`);
 
-    await delay(2000);
-
-    await button.focus();
-    console.log(await screenReader.capture(() => page.keyboard.press("Enter")));
-
-    await delay(2000);
-
-    await button.focus();
-    console.log(await screenReader.capture(() => button.click()));
-
-    console.log(await screenReader.spokenPhraseLog());
+    expect(spokenPhrase).toBe("testing testing 123");
   });
 });

--- a/examples/playwright-screenreader/tests/chromium/chromium.spec.ts
+++ b/examples/playwright-screenreader/tests/chromium/chromium.spec.ts
@@ -1,7 +1,5 @@
 import { platform, release } from "os";
-import { expect } from "@playwright/test";
 import { headerNavigation } from "../headerNavigation";
-import { log } from "../../../log";
 import { logIncludesExpectedPhrases } from "../../../logIncludesExpectedPhrases";
 import spokenPhraseSnapshot from "./chromium.spokenPhrase.snapshot.json";
 import { screenReaderTest as test } from "../../screenreader-test";
@@ -42,60 +40,5 @@ test.describe("Chromium Playwright Screen Reader", () => {
     console.log(JSON.stringify(spokenPhraseLog, undefined, 2));
 
     logIncludesExpectedPhrases(spokenPhraseLog, spokenPhraseSnapshot);
-  });
-
-  test("I can capture screen reader output from Playwright commands", async ({
-    browser,
-    browserName,
-    page,
-    screenReader,
-  }) => {
-    const osName = platform();
-    const osVersion = release();
-    const browserVersion = browser.version();
-    const screenReaderName = screenReader.name;
-    const screenReaderVersion = screenReader.version;
-    const { retry } = test.info();
-
-    console.table({
-      osName,
-      osVersion,
-      browserName,
-      browserVersion,
-      screenReaderName,
-      screenReaderVersion,
-      retry,
-    });
-
-    log("Navigating to live region test page.");
-
-    await page.goto("about:blank", {
-      waitUntil: "load",
-    });
-
-    await page.setContent(`
-      <main>
-        <h1>Example 1</h1>
-        <button id="trigger">Update</button>
-      </main>
-
-      <div role="alert" id="live"></div>
-
-      <script>
-        document.querySelector("#trigger").addEventListener("click", () => {
-          document.querySelector("#live").textContent = "testing testing 123"
-        });
-      </script>
-    `);
-
-    const button = page.locator("#trigger");
-    await button.waitFor();
-    await screenReader.navigateToWebContent();
-
-    log(`Performing capture: Playwright click`);
-    const { spokenPhrase } = await screenReader.capture(() => button.click());
-    log(`Screen reader output: "${spokenPhrase}".`);
-
-    expect(spokenPhrase).toBe("testing testing 123");
   });
 });

--- a/examples/playwright-screenreader/tests/chromium/chromium.spec.ts
+++ b/examples/playwright-screenreader/tests/chromium/chromium.spec.ts
@@ -1,5 +1,7 @@
 import { platform, release } from "os";
+import { delay } from "../delay";
 import { headerNavigation } from "../headerNavigation";
+import { log } from "../../../log";
 import { logIncludesExpectedPhrases } from "../../../logIncludesExpectedPhrases";
 import spokenPhraseSnapshot from "./chromium.spokenPhrase.snapshot.json";
 import { srTest as test } from "../../screenreader-test";
@@ -40,5 +42,82 @@ test.describe("Chromium Playwright Screen Reader", () => {
     console.log(JSON.stringify(spokenPhraseLog, undefined, 2));
 
     logIncludesExpectedPhrases(spokenPhraseLog, spokenPhraseSnapshot);
+  });
+
+  test("I can capture screen reader output from Playwright commands", async ({
+    browser,
+    browserName,
+    page,
+    screenReader,
+  }) => {
+    const osName = platform();
+    const osVersion = release();
+    const browserVersion = browser.version();
+    const screenReaderName = screenReader.name;
+    const screenReaderVersion = screenReader.version;
+    const { retry } = test.info();
+
+    console.table({
+      osName,
+      osVersion,
+      browserName,
+      browserVersion,
+      screenReaderName,
+      screenReaderVersion,
+      retry,
+    });
+
+    log("Navigating to live region test page.");
+    await page.goto("about:blank", {
+      waitUntil: "load",
+    });
+
+    await page.setContent(`
+      <main>
+        <h1>Example 1</h1>
+        <button id="trigger">Update</button>
+      </main>
+
+      <div role="alert" id="live"></div>
+
+      <script>
+        document.querySelector("#trigger").addEventListener("click", () => {
+          document.querySelector("#live").textContent = "testing testing 123"
+        });
+
+        setInterval(() => {
+          document.querySelector("#cart-status").textContent = Math.random();
+        }, 2000);
+      </script>
+    `);
+
+    const input = page.locator("#add-to-cart");
+    await input.waitFor();
+    await delay(500);
+
+    await screenReader.stop();
+    await screenReader.start({ capture: "initial" });
+
+    await screenReader.navigateToWebContent();
+
+    console.log(
+      await screenReader.capture(() =>
+        page.evaluate(() => {
+          document.querySelector("#live")!.textContent = "Playwright overwrite";
+        }),
+      ),
+    );
+
+    await delay(2000);
+
+    await input.focus();
+    console.log(await screenReader.capture(() => page.keyboard.press("Enter")));
+
+    await delay(2000);
+
+    await input.focus();
+    console.log(await screenReader.capture(() => input.click()));
+
+    console.log(await screenReader.spokenPhraseLog());
   });
 });

--- a/examples/playwright-screenreader/tests/chromium/chromium.spec.ts
+++ b/examples/playwright-screenreader/tests/chromium/chromium.spec.ts
@@ -86,17 +86,14 @@ test.describe("Chromium Playwright Screen Reader", () => {
         });
 
         setInterval(() => {
-          document.querySelector("#cart-status").textContent = Math.random();
+          document.querySelector("#live").textContent = Math.random();
         }, 2000);
       </script>
     `);
 
-    const input = page.locator("#add-to-cart");
-    await input.waitFor();
+    const button = page.locator("#trigger");
+    await button.waitFor();
     await delay(500);
-
-    await screenReader.stop();
-    await screenReader.start({ capture: "initial" });
 
     await screenReader.navigateToWebContent();
 
@@ -110,13 +107,13 @@ test.describe("Chromium Playwright Screen Reader", () => {
 
     await delay(2000);
 
-    await input.focus();
+    await button.focus();
     console.log(await screenReader.capture(() => page.keyboard.press("Enter")));
 
     await delay(2000);
 
-    await input.focus();
-    console.log(await screenReader.capture(() => input.click()));
+    await button.focus();
+    console.log(await screenReader.capture(() => button.click()));
 
     console.log(await screenReader.spokenPhraseLog());
   });

--- a/examples/playwright-screenreader/tests/delay.ts
+++ b/examples/playwright-screenreader/tests/delay.ts
@@ -1,3 +1,0 @@
-export async function delay(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}

--- a/examples/playwright-screenreader/tests/headerNavigation.ts
+++ b/examples/playwright-screenreader/tests/headerNavigation.ts
@@ -1,4 +1,4 @@
-import { delay } from "./delay";
+import { delay } from "../../../src/delay";
 import { log } from "../../log";
 import { Page } from "@playwright/test";
 import { ScreenReaderPlaywright } from "../screenreader-test";

--- a/examples/playwright-voiceover/tests/chromium/chromium.spec.ts
+++ b/examples/playwright-voiceover/tests/chromium/chromium.spec.ts
@@ -3,7 +3,7 @@ import { headerNavigation } from "../headerNavigation";
 import itemTextSnapshot from "./chromium.itemText.snapshot.json";
 import { logIncludesExpectedPhrases } from "../../../logIncludesExpectedPhrases";
 import spokenPhraseSnapshot from "./chromium.spokenPhrase.snapshot.json";
-import { voTest as test } from "../../voiceover-test";
+import { voiceOverTest as test } from "../../voiceover-test";
 
 const record = async (filepath: string) => {
   try {

--- a/examples/playwright-voiceover/tests/delay.ts
+++ b/examples/playwright-voiceover/tests/delay.ts
@@ -1,3 +1,0 @@
-export async function delay(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}

--- a/examples/playwright-voiceover/tests/firefox/firefox.spec.ts
+++ b/examples/playwright-voiceover/tests/firefox/firefox.spec.ts
@@ -3,7 +3,7 @@ import { headerNavigation } from "../headerNavigation";
 import itemTextSnapshot from "./firefox.itemText.snapshot.json";
 import { logIncludesExpectedPhrases } from "../../../logIncludesExpectedPhrases";
 import spokenPhraseSnapshot from "./firefox.spokenPhrase.snapshot.json";
-import { voTest as test } from "../../voiceover-test";
+import { voiceOverTest as test } from "../../voiceover-test";
 
 const record = async (filepath: string) => {
   try {
@@ -16,6 +16,16 @@ const record = async (filepath: string) => {
     );
   }
 };
+
+test.use({
+  voiceOverStartOptions: {
+    capture: "initial",
+    settings: {
+      SCRCategories_SCRCategorySystemWide_SCRSpeechLanguages_default_SCRSpeechComponentSettings_SCRVoiceIdentifier:
+        "com.apple.speech.synthesis.voice.custom.siri.martha.compact",
+    },
+  },
+});
 
 test.describe("Firefox Playwright VoiceOver", () => {
   test("I can navigate the Guidepup Github page", async ({

--- a/examples/playwright-voiceover/tests/headerNavigation.ts
+++ b/examples/playwright-voiceover/tests/headerNavigation.ts
@@ -1,4 +1,4 @@
-import { delay } from "./delay";
+import { delay } from "../../../src/delay";
 import { log } from "../../log";
 import { Page } from "@playwright/test";
 import { VoiceOverPlaywright } from "../voiceover-test";

--- a/examples/playwright-voiceover/tests/webkit/webkit.spec.ts
+++ b/examples/playwright-voiceover/tests/webkit/webkit.spec.ts
@@ -1,5 +1,4 @@
 import { platform, release } from "os";
-import { delay } from "../delay";
 import { expect } from "@playwright/test";
 import { headerNavigation } from "../headerNavigation";
 import itemTextSnapshotDocs from "./webkit.itemText.docs.snapshot.json";
@@ -7,7 +6,7 @@ import { log } from "../../../log";
 import { logIncludesExpectedPhrases } from "../../../logIncludesExpectedPhrases";
 import spokenPhraseSnapshotDocs from "./webkit.spokenPhrase.docs.snapshot.json";
 import spokenPhraseSnapshotTextarea from "./webkit.spokenPhrase.textarea.snapshot.json";
-import { voTest as test } from "../../voiceover-test";
+import { voiceOverTest as test } from "../../voiceover-test";
 
 const record = async (filepath: string) => {
   try {
@@ -110,10 +109,7 @@ test.describe("Webkit Playwright VoiceOver", () => {
 
       const input = page.locator("#test");
       await input.waitFor();
-      await delay(500);
-
       await voiceOver.navigateToWebContent();
-      await delay(500);
 
       log(`Performing command: "VO+Right Arrow"`);
       await voiceOver.next();
@@ -142,90 +138,6 @@ test.describe("Webkit Playwright VoiceOver", () => {
       console.log(JSON.stringify(spokenPhraseLog, undefined, 2));
 
       logIncludesExpectedPhrases(spokenPhraseLog, spokenPhraseSnapshotTextarea);
-    } finally {
-      stopRecording?.();
-    }
-  });
-
-  test("I can capture screen reader output from Playwright commands", async ({
-    browser,
-    browserName,
-    page,
-    voiceOver,
-  }) => {
-    const osName = platform();
-    const osVersion = release();
-    const browserVersion = browser.version();
-    const screenReaderName = voiceOver.name;
-    const screenReaderVersion = voiceOver.version;
-    const { retry } = test.info();
-    const recordingFilePath = `./recordings/playwright-voiceOver-live-region-playwright-capture-${osName}-${osVersion}-${browserName}-${browserVersion}-attempt-${retry}-${+new Date()}.mov`;
-
-    console.table({
-      osName,
-      osVersion,
-      browserName,
-      browserVersion,
-      screenReaderName,
-      screenReaderVersion,
-      retry,
-    });
-
-    let stopRecording: (() => void) | undefined;
-
-    try {
-      stopRecording = await record(recordingFilePath);
-
-      log("Navigating to live region test page.");
-      await page.goto("about:blank", {
-        waitUntil: "load",
-      });
-
-      await page.setContent(`
-      <main>
-        <h1>Example 1</h1>
-        <button id="trigger">Update</button>
-      </main>
-
-      <div role="alert" id="live"></div>
-
-      <script>
-        document.querySelector("#trigger").addEventListener("click", () => {
-          document.querySelector("#live").textContent = "testing testing 123"
-        });
-
-        setInterval(() => {
-          document.querySelector("#live").textContent = Math.random();
-        }, 2000);
-      </script>
-    `);
-
-      const button = page.locator("#trigger");
-      await button.waitFor();
-      await delay(500);
-
-      await voiceOver.navigateToWebContent();
-
-      console.log(
-        await voiceOver.capture(() =>
-          page.evaluate(() => {
-            document.querySelector("#live")!.textContent =
-              "Playwright overwrite";
-          }),
-        ),
-      );
-
-      await delay(2000);
-
-      await button.focus();
-      console.log(await voiceOver.capture(() => page.keyboard.press("Enter")));
-
-      await delay(2000);
-
-      await button.focus();
-      console.log(await voiceOver.capture(() => button.click()));
-
-      console.log(await voiceOver.spokenPhraseLog());
     } finally {
       stopRecording?.();
     }

--- a/examples/playwright-voiceover/tests/webkit/webkit.spec.ts
+++ b/examples/playwright-voiceover/tests/webkit/webkit.spec.ts
@@ -146,4 +146,88 @@ test.describe("Webkit Playwright VoiceOver", () => {
       stopRecording?.();
     }
   });
+
+  test("I can capture screen reader output from Playwright commands", async ({
+    browser,
+    browserName,
+    page,
+    voiceOver,
+  }) => {
+    const osName = platform();
+    const osVersion = release();
+    const browserVersion = browser.version();
+    const screenReaderName = voiceOver.name;
+    const screenReaderVersion = voiceOver.version;
+    const { retry } = test.info();
+    const recordingFilePath = `./recordings/playwright-voiceOver-live-region-playwright-capture-${osName}-${osVersion}-${browserName}-${browserVersion}-attempt-${retry}-${+new Date()}.mov`;
+
+    console.table({
+      osName,
+      osVersion,
+      browserName,
+      browserVersion,
+      screenReaderName,
+      screenReaderVersion,
+      retry,
+    });
+
+    let stopRecording: (() => void) | undefined;
+
+    try {
+      stopRecording = await record(recordingFilePath);
+
+      log("Navigating to live region test page.");
+      await page.goto("about:blank", {
+        waitUntil: "load",
+      });
+
+      await page.setContent(`
+      <main>
+        <h1>Example 1</h1>
+        <button id="trigger">Update</button>
+      </main>
+
+      <div role="alert" id="live"></div>
+
+      <script>
+        document.querySelector("#trigger").addEventListener("click", () => {
+          document.querySelector("#live").textContent = "testing testing 123"
+        });
+
+        setInterval(() => {
+          document.querySelector("#live").textContent = Math.random();
+        }, 2000);
+      </script>
+    `);
+
+      const button = page.locator("#trigger");
+      await button.waitFor();
+      await delay(500);
+
+      await voiceOver.navigateToWebContent();
+
+      console.log(
+        await voiceOver.capture(() =>
+          page.evaluate(() => {
+            document.querySelector("#live")!.textContent =
+              "Playwright overwrite";
+          }),
+        ),
+      );
+
+      await delay(2000);
+
+      await button.focus();
+      console.log(await voiceOver.capture(() => page.keyboard.press("Enter")));
+
+      await delay(2000);
+
+      await button.focus();
+      console.log(await voiceOver.capture(() => button.click()));
+
+      console.log(await voiceOver.spokenPhraseLog());
+    } finally {
+      stopRecording?.();
+    }
+  });
 });

--- a/examples/playwright-voiceover/voiceover-test.ts
+++ b/examples/playwright-voiceover/voiceover-test.ts
@@ -1,28 +1,49 @@
-import { macOSActivate, MacOSKeyCodes, voiceOver } from "../../src";
+import type { CommandOptions, VoiceOver } from "../../src";
+import {
+  macOSActivate,
+  MacOSKeyCodes,
+  voiceOver,
+  voiceOverKeyCodeCommands,
+} from "../../src";
+import { applicationNameMap } from "../applicationNameMap";
+import { delay } from "../../src/delay";
+import type { StartOptions } from "../../src/StartOptions";
 import { test } from "@playwright/test";
-import type { VoiceOver } from "../../src";
 
-const applicationNameMap = {
-  chromium: "Google Chrome For Testing",
-  chrome: "Google Chrome",
-  "chrome-beta": "Google Chrome Beta",
-  msedge: "Microsoft Edge",
-  "msedge-beta": "Microsoft Edge Beta",
-  "msedge-dev": "Microsoft Edge Dev",
-  firefox: "Nightly",
-  webkit: "Playwright",
-};
-
+/**
+ * [API Reference](https://www.guidepup.dev/docs/api/class-voiceover)
+ *
+ * This object can be used to launch and control VoiceOver.
+ *
+ * Here's a typical example:
+ *
+ * ```ts
+ * import { voiceOver } from "@guidepup/guidepup";
+ *
+ * (async () => {
+ *   // Start VoiceOver.
+ *   await voiceOver.start();
+ *
+ *   // Move to the next item.
+ *   await voiceOver.next();
+ *
+ *   // ... perform some commands.
+ *
+ *   // Stop VoiceOver.
+ *   await voiceOver.stop();
+ * })();
+ * ```
+ */
 export interface VoiceOverPlaywright extends VoiceOver {
   /**
    * Guidepup Playwright specific command that navigates VoiceOver to the beginning
    * of the browser's web content.
    *
-   * This command should be used after page navigation.
-   *
-   * Note: this command clears all logs.
+   * This command should be used after a page navigation has completed.
    */
-  navigateToWebContent(): Promise<void>;
+  navigateToWebContent(
+    options?: Pick<CommandOptions, "capture">,
+  ): Promise<void>;
 }
 
 const voiceOverPlaywright: VoiceOverPlaywright =
@@ -32,10 +53,43 @@ const voiceOverPlaywright: VoiceOverPlaywright =
  * These tests extend the default Playwright environment that launches the
  * browser with a running instance of the VoiceOver screen reader for MacOS.
  *
- * A fresh started VoiceOver instance `vo` is provided to each test.
+ * A fresh started VoiceOver instance `voiceOver` is provided to each test.
  */
-const voTest = test.extend<{ voiceOver: VoiceOverPlaywright }>({
-  voiceOver: async ({ browserName, page }, use) => {
+export const voiceOverTest = test.extend<{
+  /**
+   * [API Reference](https://www.guidepup.dev/docs/api/class-voiceover)
+   *
+   * This object can be used to launch and control VoiceOver.
+   *
+   * Here's a typical example:
+   *
+   * ```ts
+   * import { voiceOver } from "@guidepup/guidepup";
+   *
+   * (async () => {
+   *   // Start VoiceOver.
+   *   await voiceOver.start();
+   *
+   *   // Move to the next item.
+   *   await voiceOver.next();
+   *
+   *   // ... perform some commands.
+   *
+   *   // Stop VoiceOver.
+   *   await voiceOver.stop();
+   * })();
+   * ```
+   */
+  voiceOver: VoiceOverPlaywright;
+  /**
+   * [API Reference](https://www.guidepup.dev/docs/api/class-start-options)
+   *
+   * Options to start VoiceOver with, see also [voiceOver.start([options])](https://www.guidepup.dev/docs/api/class-voiceover#voiceover-start).
+   */
+  voiceOverStartOptions: StartOptions;
+}>({
+  voiceOverStartOptions: { capture: "initial" },
+  voiceOver: async ({ browserName, page, voiceOverStartOptions }, use) => {
     try {
       const applicationName = applicationNameMap[browserName];
 
@@ -43,46 +97,111 @@ const voTest = test.extend<{ voiceOver: VoiceOverPlaywright }>({
         throw new Error(`Browser ${browserName} is not installed.`);
       }
 
-      voiceOverPlaywright.navigateToWebContent = async (
-        clearLogs: boolean = true,
-      ) => {
+      voiceOverPlaywright.navigateToWebContent = async ({ capture } = {}) => {
+        // Ensure application is brought to front and focused.
         await macOSActivate(applicationName);
 
-        await voiceOverPlaywright.perform({ keyCode: MacOSKeyCodes.Control });
+        // Cancel auto navigation.
+        await voiceOverPlaywright.perform(
+          { keyCode: MacOSKeyCodes.Control },
+          { capture: false },
+        );
+        await delay(100);
 
+        // Ensure the document is ready and focused.
         await page.bringToFront();
         await page.locator("body").waitFor();
 
-        await voiceOverPlaywright.perform(
-          voiceOverPlaywright.keyboardCommands.openItemChooser,
-        );
+        try {
+          // Add an interactive marker to the page that will force VoiceOver
+          // to listen to events emitted by Playwright interactions when
+          // navigated to.
+          await page.evaluate(() => {
+            const marker = document.createElement("input");
 
-        await voiceOverPlaywright.type("web content");
+            marker.id = "__guidepup_marker__";
+            marker.type = "text";
+            marker.value = "Guidepup Marker";
+            marker.readOnly = true;
+            marker.tabIndex = -1;
+            marker.autocomplete = "off";
+            marker.setAttribute("aria-label", "Guidepup Marker");
+            marker.style.cssText = `
+              position: absolute;
+              width: 1px;
+              height: 1px;
+              overflow: hidden;
+              clip: rect(0 0 0 0);
+              white-space: nowrap;
+            `;
 
-        await voiceOverPlaywright.perform({ keyCode: MacOSKeyCodes.Enter });
+            document.body.prepend(marker);
+          });
 
-        await voiceOverPlaywright.interact();
+          // Open the web item chooser.
+          await voiceOverPlaywright.perform(
+            voiceOverKeyCodeCommands.openItemChooser,
+            { capture: false },
+          );
+          await delay(500);
 
-        await voiceOverPlaywright.perform(
-          voiceOverPlaywright.keyboardCommands.moveToBeginningOfText,
-        );
+          // Filter by "web content" - currently web content items for all browsers
+          // are suffixed by "web content".
+          for (const character of "web content") {
+            await voiceOverPlaywright.type(character, { capture: false });
+            await delay(100);
+          }
 
-        await voiceOverPlaywright.perform({ keyCode: MacOSKeyCodes.Control });
+          // Select the web content window spot.
+          await voiceOverPlaywright.perform(
+            { keyCode: MacOSKeyCodes.Enter },
+            { capture: false },
+          );
+          await delay(100);
 
-        if (clearLogs) {
-          await voiceOverPlaywright.clearItemTextLog();
-          await voiceOverPlaywright.clearSpokenPhraseLog();
+          // Navigate into web content.
+          await voiceOverPlaywright.interact({ capture: false });
+          await delay(100);
+
+          // Navigate to the beginning of the web content.
+          await voiceOverPlaywright.perform(
+            voiceOverKeyCodeCommands.moveToBeginningOfText,
+            { capture: false },
+          );
+          await delay(100);
+
+          // Cancel auto navigation
+          await voiceOverPlaywright.perform(
+            { keyCode: MacOSKeyCodes.Control },
+            { capture: false },
+          );
+          await delay(100);
+
+          // Navigate to the Guidepup marker element at beginning of the web
+          // content.
+          await voiceOverPlaywright.perform(
+            voiceOverKeyCodeCommands.moveToBeginningOfText,
+            { capture: false },
+          );
+          await delay(100);
+
+          // Navigate to the first element of the page using the provided
+          // capture settings.
+          await voiceOverPlaywright.next({ capture });
+        } finally {
+          // Remove the temporary Guidepup marker element to restore original
+          // page structure.
+          await page.evaluate(() => {
+            const marker = document.querySelector("#__guidepup_marker__");
+
+            if (marker) {
+              document.body.removeChild(marker);
+            }
+          });
         }
       };
 
-      await voiceOverPlaywright.start({
-        capture: "initial",
-        settings: {
-          SCRCategories_SCRCategorySystemWide_SCRSpeechLanguages_default_SCRSpeechComponentSettings_SCRVoiceIdentifier:
-            "com.apple.speech.synthesis.voice.custom.siri.martha.compact",
-        },
-      });
-
+      await voiceOverPlaywright.start(voiceOverStartOptions);
       await use(voiceOverPlaywright);
     } finally {
       try {
@@ -93,5 +212,3 @@ const voTest = test.extend<{ voiceOver: VoiceOverPlaywright }>({
     }
   },
 });
-
-export { voTest };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guidepup/guidepup",
-  "version": "0.32.1",
+  "version": "0.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@guidepup/guidepup",
-      "version": "0.32.1",
+      "version": "0.33.0",
       "license": "MIT",
       "dependencies": {
         "plist": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guidepup/guidepup",
-  "version": "0.32.1",
+  "version": "0.33.0",
   "description": "Screen reader automation library for testing.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/Capture.ts
+++ b/src/Capture.ts
@@ -1,0 +1,5 @@
+export interface Capture<T> {
+  itemText: string;
+  result: T;
+  spokenPhrase: string;
+}

--- a/src/IScreenReader.ts
+++ b/src/IScreenReader.ts
@@ -1,4 +1,5 @@
-import { ClickOptions } from "./ClickOptions";
+import type { Capture } from "./Capture";
+import type { ClickOptions } from "./ClickOptions";
 import type { CommandOptions } from "./CommandOptions";
 import type { KeyboardOptions } from "./KeyboardOptions";
 import type { StartOptions } from "./StartOptions";
@@ -226,8 +227,24 @@ export interface IScreenReader {
   /**
    * Returns the value of a setting for this screen reader instance.
    *
-   * @param key The setting name.
+   * @param {string} key The setting name.
    * @returns {unknown} The setting value.
    */
   getSetting(key: string): unknown;
+
+  /**
+   * Capture screen reader output produced by an action.
+   *
+   * The action can be performed using an external automation tool such as
+   * Playwright. Guidepup captures the screen reader output associated with
+   * the action and returns it together with the action's result.
+   *
+   * @param {() => Promise<T>} action The action to perform while capturing screen reader output.
+   * @param {object} [options] Additional options.
+   * @returns {Promise<Capture<T>>} The action's result and captured screen reader output.
+   */
+  capture<T>(
+    action: () => Promise<T>,
+    options?: CommandOptions,
+  ): Promise<Capture<T>>;
 }

--- a/src/ScreenReader.ts
+++ b/src/ScreenReader.ts
@@ -1,8 +1,9 @@
+import type { Capture } from "./Capture";
 import type { ClickOptions } from "./ClickOptions";
 import type { CommandOptions } from "./CommandOptions";
 import { ERR_NO_AVAILABLE_SUPPORTED_SCREEN_READERS } from "./errors";
 import type { IScreenReader } from "./IScreenReader";
-import { KeyboardOptions } from "./KeyboardOptions";
+import type { KeyboardOptions } from "./KeyboardOptions";
 import { nvda } from "./windows";
 import type { StartOptions } from "./StartOptions";
 import { voiceOver } from "./macOS";
@@ -309,5 +310,23 @@ export class ScreenReader implements IScreenReader {
    */
   getSetting(key: string): unknown {
     return this.implementation.getSetting(key);
+  }
+
+  /**
+   * Capture screen reader output produced by an action.
+   *
+   * The action can be performed using an external automation tool such as
+   * Playwright. Guidepup captures the screen reader output associated with
+   * the action and returns it together with the action's result.
+   *
+   * @param {() => Promise<T>} action The action to perform while capturing screen reader output.
+   * @param {object} [options] Additional options.
+   * @returns {Promise<Capture<T>>} The action's result and captured screen reader output.
+   */
+  async capture<T>(
+    action: () => Promise<T>,
+    options?: CommandOptions,
+  ): Promise<Capture<T>> {
+    return await this.implementation.capture(action, options);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./macOS";
 export * from "./windows";
+export type { Capture } from "./Capture";
 export type { ClickOptions } from "./ClickOptions";
 export type { CommandOptions } from "./CommandOptions";
 export type { KeyboardCommand } from "./KeyboardCommand";
@@ -7,6 +8,7 @@ export type { KeyboardOptions } from "./KeyboardOptions";
 export type { KeyCodeCommand } from "./KeyCodeCommand";
 export type { KeystrokeCommand } from "./KeystrokeCommand";
 export type { IScreenReader } from "./IScreenReader";
+export type { StartOptions } from "./StartOptions";
 
 import { ScreenReader } from "./ScreenReader";
 

--- a/src/macOS/VoiceOver/VoiceOver.test.ts
+++ b/src/macOS/VoiceOver/VoiceOver.test.ts
@@ -94,6 +94,7 @@ jest.mock("./waitForRunning", () => ({
 }));
 
 const VoiceOverClientStub = {
+  enqueueAndTap: jest.fn(),
   stop: jest.fn(),
 };
 
@@ -1259,6 +1260,60 @@ describe("VoiceOver", () => {
       await expect(async () => await vo.itemText()).rejects.toThrow(
         ERR_VOICE_OVER_NOT_RUNNING,
       );
+    });
+  });
+
+  describe("capture", () => {
+    const actionStub = jest.fn();
+    const outputStub = {
+      itemText: "test-item-text",
+      result: "test-result",
+      spokenPhrase: "test-spoken-phrase",
+    };
+
+    beforeEach(() => {
+      jest
+        .mocked(VoiceOverClientStub.enqueueAndTap)
+        .mockResolvedValue(outputStub);
+    });
+
+    describe("when VoiceOver is not running", () => {
+      it("should throw an error", async () => {
+        await expect(async () => await vo.capture(actionStub)).rejects.toThrow(
+          ERR_VOICE_OVER_NOT_RUNNING,
+        );
+      });
+    });
+
+    describe.each`
+      description          | options
+      ${"without options"} | ${undefined}
+      ${"with options"}    | ${{}}
+    `("when called $description", ({ options }) => {
+      let output: unknown;
+
+      beforeEach(async () => {
+        await vo.start();
+        output = await vo.capture(actionStub, options);
+        await vo.stop();
+      });
+
+      it("should enqueue and tap an async wrapper of the provided action", async () => {
+        expect(VoiceOverClientStub.enqueueAndTap).toHaveBeenCalledWith(
+          expect.any(Function),
+          options,
+        );
+
+        expect(actionStub).not.toHaveBeenCalled();
+
+        await jest.mocked(VoiceOverClientStub.enqueueAndTap).mock.calls[0][0]();
+
+        expect(actionStub).toHaveBeenCalled();
+      });
+
+      it("should return the result of the action, item text, and spoken phrase", async () => {
+        expect(output).toBe(outputStub);
+      });
     });
   });
 });

--- a/src/macOS/VoiceOver/VoiceOver.ts
+++ b/src/macOS/VoiceOver/VoiceOver.ts
@@ -12,14 +12,15 @@ import {
   setPreferences,
   unmountGuidepupPreferences,
 } from "./preferences";
-import { ClickOptions } from "../../ClickOptions";
-import { CommanderCommands } from "./CommanderCommands";
+import type { Capture } from "../../Capture";
+import type { ClickOptions } from "../../ClickOptions";
+import type { CommanderCommands } from "./CommanderCommands";
 import type { CommandOptions } from "../../CommandOptions";
 import type { IScreenReader } from "../../IScreenReader";
 import { isKeyboard } from "../../isKeyboard";
 import { isMacOS } from "../isMacOS";
-import { KeyboardCommand } from "../KeyboardCommand";
-import { KeyboardOptions } from "../../KeyboardOptions";
+import type { KeyboardCommand } from "../KeyboardCommand";
+import type { KeyboardOptions } from "../../KeyboardOptions";
 import { keyCodeCommands } from "./keyCodeCommands";
 import type { Prettify } from "../../typeHelpers";
 import { release } from "node:os";
@@ -1309,10 +1310,32 @@ export class VoiceOver implements IScreenReader {
    * })();
    * ```
    *
-   * @param key The setting name.
+   * @param {string} key The setting name.
    * @returns {unknown} The setting value.
    */
   getSetting(key: string): unknown {
     return getPreference(key);
+  }
+
+  /**
+   * Capture VoiceOver output produced by an action.
+   *
+   * The action can be performed using an external automation tool such as
+   * Playwright. Guidepup captures the VoiceOver output associated with
+   * the action and returns it together with the action's result.
+   *
+   * @param {() => Promise<T>} action The action to perform while capturing VoiceOver output.
+   * @param {object} [options] Additional options.
+   * @returns {Promise<Capture<T>>} The action's result and captured VoiceOver output.
+   */
+  async capture<T>(
+    action: () => Promise<T> | T,
+    options?: CommandOptions,
+  ): Promise<Capture<T>> {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
+    }
+
+    return await this.#client.enqueueAndTap(async () => action(), options);
   }
 }

--- a/src/macOS/VoiceOver/VoiceOverClient.test.ts
+++ b/src/macOS/VoiceOver/VoiceOverClient.test.ts
@@ -103,7 +103,11 @@ describe("VoiceOverClient", () => {
         });
 
         it("should return the action's result", async () => {
-          await expect(resultPromise).resolves.toBe(expectedResult);
+          await expect(resultPromise).resolves.toEqual({
+            itemText: `cleaned_${itemTextDummy}`,
+            result: expectedResult,
+            spokenPhrase: `cleaned_${lastSpokenPhraseDummy}`,
+          });
         });
 
         it("should return the item text from the last action", async () => {
@@ -163,7 +167,11 @@ describe("VoiceOverClient", () => {
         });
 
         it("should return the action's result", async () => {
-          await expect(resultPromise).resolves.toBe(expectedResult);
+          await expect(resultPromise).resolves.toEqual({
+            itemText: `cleaned_${itemTextDummy}`,
+            result: expectedResult,
+            spokenPhrase: `cleaned_${lastSpokenPhraseDummy}`,
+          });
         });
 
         it("should return the item text from the last action", async () => {
@@ -219,7 +227,11 @@ describe("VoiceOverClient", () => {
         });
 
         it("should return the action's result", async () => {
-          await expect(resultPromise).resolves.toBe(expectedResult);
+          await expect(resultPromise).resolves.toEqual({
+            itemText: "",
+            result: expectedResult,
+            spokenPhrase: "",
+          });
         });
 
         it("should not return the item text from the last action", async () => {
@@ -417,7 +429,11 @@ describe("VoiceOverClient", () => {
         });
 
         it("should return the action's result", async () => {
-          await expect(resultPromise).resolves.toBe(expectedResult);
+          await expect(resultPromise).resolves.toEqual({
+            itemText: `cleaned_${itemTextDummy}`,
+            result: expectedResult,
+            spokenPhrase: `cleaned_${lastSpokenPhraseDummy}`,
+          });
         });
 
         it("should return the item text from the last action", async () => {
@@ -477,7 +493,11 @@ describe("VoiceOverClient", () => {
         });
 
         it("should return the action's result", async () => {
-          await expect(resultPromise).resolves.toBe(expectedResult);
+          await expect(resultPromise).resolves.toEqual({
+            itemText: `cleaned_${itemTextDummy}`,
+            result: expectedResult,
+            spokenPhrase: `cleaned_${lastSpokenPhraseDummy}`,
+          });
         });
 
         it("should return the item text from the last action", async () => {
@@ -561,7 +581,11 @@ describe("VoiceOverClient", () => {
         });
 
         it("should return the action's result", async () => {
-          await expect(resultPromise).resolves.toBe(expectedResult);
+          await expect(resultPromise).resolves.toEqual({
+            itemText: "",
+            result: expectedResult,
+            spokenPhrase: "",
+          });
         });
 
         it("should not return the item text from the last action", async () => {
@@ -637,7 +661,11 @@ describe("VoiceOverClient", () => {
         });
 
         it("should return the action's result", async () => {
-          await expect(resultPromise).resolves.toBe(expectedResult);
+          await expect(resultPromise).resolves.toEqual({
+            itemText: "",
+            result: expectedResult,
+            spokenPhrase: "",
+          });
         });
 
         it("should not return the item text from the last action", async () => {
@@ -693,7 +721,11 @@ describe("VoiceOverClient", () => {
         });
 
         it("should return the action's result", async () => {
-          await expect(resultPromise).resolves.toBe(expectedResult);
+          await expect(resultPromise).resolves.toEqual({
+            itemText: `cleaned_${itemTextDummy}`,
+            result: expectedResult,
+            spokenPhrase: `cleaned_${lastSpokenPhraseDummy}`,
+          });
         });
 
         it("should return the item text from the last action", async () => {
@@ -749,7 +781,11 @@ describe("VoiceOverClient", () => {
         });
 
         it("should return the action's result", async () => {
-          await expect(resultPromise).resolves.toBe(expectedResult);
+          await expect(resultPromise).resolves.toEqual({
+            itemText: "",
+            result: expectedResult,
+            spokenPhrase: "",
+          });
         });
 
         it("should not return the item text from the last action", async () => {
@@ -789,9 +825,21 @@ describe("VoiceOverClient", () => {
 
       const [r1, r2, r3] = await Promise.all([promise1, promise2, promise3]);
 
-      expect(r1).toBe(result1);
-      expect(r2).toBe(result2);
-      expect(r3).toBe(result3);
+      expect(r1).toEqual({
+        itemText: `cleaned_${itemTextDummy}`,
+        result: result1,
+        spokenPhrase: `cleaned_${lastSpokenPhraseDummy}`,
+      });
+      expect(r2).toEqual({
+        itemText: `cleaned_${itemTextDummy}`,
+        result: result2,
+        spokenPhrase: `cleaned_${lastSpokenPhraseDummy}`,
+      });
+      expect(r3).toEqual({
+        itemText: `cleaned_${itemTextDummy}`,
+        result: result3,
+        spokenPhrase: `cleaned_${lastSpokenPhraseDummy}`,
+      });
 
       expect(await voiceOverClientWithCapture.itemTextLog()).toEqual([
         `cleaned_${itemTextDummy}`,
@@ -873,7 +921,11 @@ describe("VoiceOverClient", () => {
       await expect(rejectingPromise).rejects.toBe(testError);
       const result = await successPromise;
 
-      expect(result).toBe(successResult);
+      expect(result).toEqual({
+        itemText: `cleaned_${itemTextDummy}`,
+        result: successResult,
+        spokenPhrase: `cleaned_${lastSpokenPhraseDummy}`,
+      });
 
       // Only the successful action should be logged
       expect(await voiceOverClientWithCapture.itemTextLog()).toEqual([

--- a/src/macOS/VoiceOver/VoiceOverClient.ts
+++ b/src/macOS/VoiceOver/VoiceOverClient.ts
@@ -6,6 +6,7 @@ import {
   SPOKEN_PHRASES_POLL_INTERVAL,
   SPOKEN_PHRASES_RETRY_COUNT,
 } from "./constants";
+import type { Capture } from "../../Capture";
 import { cleanSpokenPhrase } from "./cleanSpokenPhrase";
 import { CommandOptions } from "../../CommandOptions";
 import { DEFAULT_CAPTURE } from "../../constants";
@@ -124,14 +125,14 @@ export class VoiceOverClient {
   async enqueueAndTap<T>(
     action: () => Promise<T>,
     options?: Pick<CommandOptions, "capture">,
-  ): Promise<T> {
+  ): Promise<Capture<T>> {
     if (this.#stopped) {
       throw new Error(ERR_VOICE_OVER_NOT_RUNNING);
     }
 
     let resolve, reject;
 
-    const promise = new Promise<T>((_resolve, _reject) => {
+    const promise = new Promise<Capture<T>>((_resolve, _reject) => {
       resolve = _resolve;
       reject = _reject;
     });
@@ -167,17 +168,24 @@ export class VoiceOverClient {
 
       const result = await action();
 
+      let itemText: string;
+      let spokenPhrase: string;
+
       if (options?.capture ?? this.#capture) {
-        const [itemText, lastSpokenPhrase] = await Promise.all([
+        [itemText, spokenPhrase] = await Promise.all([
           this.#pollForItemText(),
           this.#pollForSpokenPhrases(options),
         ]);
 
         this.#itemTextLogStore.push(itemText);
-        this.#spokenPhraseLogStore.push(lastSpokenPhrase);
+        this.#spokenPhraseLogStore.push(spokenPhrase);
       }
 
-      resolve(result);
+      resolve({
+        itemText: itemText ?? "",
+        result,
+        spokenPhrase: spokenPhrase ?? "",
+      });
     } catch (error) {
       reject(error);
     } finally {

--- a/src/macOS/VoiceOver/VoiceOverCommander.test.ts
+++ b/src/macOS/VoiceOver/VoiceOverCommander.test.ts
@@ -23,7 +23,15 @@ describe("VoiceOverCommander", () => {
 
     jest
       .mocked(voiceOverClientStub.enqueueAndTap)
-      .mockImplementation(async (action) => await action());
+      .mockImplementation(async (action) => {
+        const result = await action();
+
+        return {
+          itemText: "test-item-text",
+          result,
+          spokenPhrase: "test-spoken-phrase",
+        };
+      });
 
     commander = new VoiceOverCommander(voiceOverClientStub);
   });

--- a/src/macOS/VoiceOver/VoiceOverCommander.ts
+++ b/src/macOS/VoiceOver/VoiceOverCommander.ts
@@ -31,7 +31,7 @@ export class VoiceOverCommander {
     command: CommanderCommands,
     options?: CommandOptions,
   ): Promise<void> {
-    return await this.#voiceOverClient.enqueueAndTap(
+    await this.#voiceOverClient.enqueueAndTap(
       () => performCommand(command, options),
       options,
     );

--- a/src/macOS/VoiceOver/VoiceOverCursor.test.ts
+++ b/src/macOS/VoiceOver/VoiceOverCursor.test.ts
@@ -40,7 +40,15 @@ describe("VoiceOverCursor", () => {
     jest.mocked(takeScreenshot).mockResolvedValue(screenshotPathDummy);
     jest
       .mocked(voiceOverClientStub.enqueueAndTap)
-      .mockImplementation(async (action) => await action());
+      .mockImplementation(async (action) => {
+        const result = await action();
+
+        return {
+          itemText: "test-item-text",
+          result,
+          spokenPhrase: "test-spoken-phrase",
+        };
+      });
 
     cursor = new VoiceOverCursor(voiceOverClientStub);
   });

--- a/src/macOS/VoiceOver/VoiceOverCursor.ts
+++ b/src/macOS/VoiceOver/VoiceOverCursor.ts
@@ -26,7 +26,7 @@ export class VoiceOverCursor {
    * @param {object} [options] Additional options.
    */
   async previous(options?: CommandOptions): Promise<void> {
-    return await this.#voiceOverClient.enqueueAndTap(
+    await this.#voiceOverClient.enqueueAndTap(
       () => move(Directions.Left, undefined, options),
       options,
     );
@@ -40,7 +40,7 @@ export class VoiceOverCursor {
    * @param {object} [options] Additional options.
    */
   async next(options?: CommandOptions): Promise<void> {
-    return await this.#voiceOverClient.enqueueAndTap(
+    await this.#voiceOverClient.enqueueAndTap(
       () => move(Directions.Right, undefined, options),
       options,
     );
@@ -52,7 +52,7 @@ export class VoiceOverCursor {
    * @param {object} [options] Additional options.
    */
   async act(options?: CommandOptions): Promise<void> {
-    return await this.#voiceOverClient.enqueueAndTap(
+    await this.#voiceOverClient.enqueueAndTap(
       () => performAction(options),
       options,
     );
@@ -66,7 +66,7 @@ export class VoiceOverCursor {
    * @param {object} [options] Additional options.
    */
   async interact(options?: CommandOptions): Promise<void> {
-    return await this.#voiceOverClient.enqueueAndTap(
+    await this.#voiceOverClient.enqueueAndTap(
       () =>
         sendKeys(
           keyCodeCommands.interactWithItem,
@@ -85,7 +85,7 @@ export class VoiceOverCursor {
    * @param {object} [options] Additional options.
    */
   async stopInteracting(options?: CommandOptions): Promise<void> {
-    return await this.#voiceOverClient.enqueueAndTap(
+    await this.#voiceOverClient.enqueueAndTap(
       () =>
         sendKeys(
           keyCodeCommands.stopInteractingWithItem,

--- a/src/macOS/VoiceOver/VoiceOverKeyboard.test.ts
+++ b/src/macOS/VoiceOver/VoiceOverKeyboard.test.ts
@@ -34,7 +34,15 @@ describe("VoiceOverKeyboard", () => {
     jest.mocked(parseKey).mockReturnValue(parsedKeyDummy);
     jest
       .mocked(voiceOverClientStub.enqueueAndTap)
-      .mockImplementation(async (action) => await action());
+      .mockImplementation(async (action) => {
+        const result = await action();
+
+        return {
+          itemText: "test-item-text",
+          result,
+          spokenPhrase: "test-spoken-phrase",
+        };
+      });
 
     keyboard = new VoiceOverKeyboard(voiceOverClientStub);
   });

--- a/src/macOS/VoiceOver/VoiceOverKeyboard.ts
+++ b/src/macOS/VoiceOver/VoiceOverKeyboard.ts
@@ -49,7 +49,7 @@ export class VoiceOverKeyboard {
    * @param {object} [options] Additional options.
    */
   async press(key: string, options?: KeyboardOptions): Promise<void> {
-    return await this.#voiceOverClient.enqueueAndTap(
+    await this.#voiceOverClient.enqueueAndTap(
       () =>
         sendKeys(
           parseKey<KeyCodeCommand>(key, Modifiers, KeyCodes),
@@ -102,7 +102,7 @@ export class VoiceOverKeyboard {
     command: KeyboardCommand,
     options?: CommandOptions,
   ): Promise<void> {
-    return await this.#voiceOverClient.enqueueAndTap(
+    await this.#voiceOverClient.enqueueAndTap(
       () => sendKeys(command, Applications.VoiceOver, options),
       options,
     );

--- a/src/macOS/VoiceOver/VoiceOverMouse.test.ts
+++ b/src/macOS/VoiceOver/VoiceOverMouse.test.ts
@@ -22,7 +22,15 @@ describe("VoiceOverMouse", () => {
 
     jest
       .mocked(voiceOverClientStub.enqueueAndTap)
-      .mockImplementation(async (action) => await action());
+      .mockImplementation(async (action) => {
+        const result = await action();
+
+        return {
+          itemText: "test-item-text",
+          result,
+          spokenPhrase: "test-spoken-phrase",
+        };
+      });
 
     mouse = new VoiceOverMouse(voiceOverClientStub);
   });

--- a/src/macOS/VoiceOver/VoiceOverMouse.ts
+++ b/src/macOS/VoiceOver/VoiceOverMouse.ts
@@ -18,9 +18,6 @@ export class VoiceOverMouse {
    * @param {object} [options] Click options.
    */
   async click(options?: ClickOptions): Promise<void> {
-    return await this.#voiceOverClient.enqueueAndTap(
-      () => click(options),
-      options,
-    );
+    await this.#voiceOverClient.enqueueAndTap(() => click(options), options);
   }
 }

--- a/src/windows/NVDA/NVDA.test.ts
+++ b/src/windows/NVDA/NVDA.test.ts
@@ -530,4 +530,58 @@ describe("NVDA", () => {
       ).rejects.toThrow(ERR_NVDA_NOT_RUNNING);
     });
   });
+
+  describe("capture", () => {
+    const actionStub = jest.fn();
+    const outputStub = {
+      itemText: "test-item-text",
+      result: "test-result",
+      spokenPhrase: "test-spoken-phrase",
+    };
+
+    beforeEach(() => {
+      jest.mocked(NVDAClientStub.enqueueAndTap).mockResolvedValue(outputStub);
+
+      nvda = new NVDA();
+    });
+
+    describe("when NVDA is not running", () => {
+      it("should throw an error", async () => {
+        await expect(
+          async () => await nvda.capture(actionStub),
+        ).rejects.toThrow(ERR_NVDA_NOT_RUNNING);
+      });
+    });
+
+    describe("when NVDA is running", () => {
+      let output: unknown;
+
+      beforeEach(async () => {
+        jest.mocked(start).mockResolvedValue(undefined);
+
+        await nvda.start();
+
+        jest.clearAllMocks();
+
+        output = await nvda.capture(actionStub);
+      });
+
+      it("should enqueue and tap an async wrapper of the provided action", async () => {
+        expect(NVDAClientStub.enqueueAndTap).toHaveBeenCalledWith(
+          expect.any(Function),
+          undefined,
+        );
+
+        expect(actionStub).not.toHaveBeenCalled();
+
+        await jest.mocked(NVDAClientStub.enqueueAndTap).mock.calls[0][0]();
+
+        expect(actionStub).toHaveBeenCalled();
+      });
+
+      it("should return the result of the action, item text, and spoken phrase", async () => {
+        expect(output).toBe(outputStub);
+      });
+    });
+  });
 });

--- a/src/windows/NVDA/NVDA.ts
+++ b/src/windows/NVDA/NVDA.ts
@@ -12,8 +12,9 @@ import {
   ERR_NVDA_NOT_RUNNING,
   ERR_NVDA_NOT_SUPPORTED,
 } from "../errors";
+import type { Capture } from "../../Capture";
 import type { ClickOptions } from "../../ClickOptions";
-import { CommandOptions } from "../../CommandOptions";
+import type { CommandOptions } from "../../CommandOptions";
 import type { IScreenReader } from "../../IScreenReader";
 import { isNVDAInstalled } from "./isNVDAInstalled";
 import { isWindows } from "../isWindows";
@@ -327,7 +328,7 @@ export class NVDA implements IScreenReader {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
-    return this.#client.enqueueAndTap(
+    await this.#client.enqueueAndTap(
       () => this.#client.sendKeyCode(keyCodeCommands.moveToPrevious),
       options,
     );
@@ -358,7 +359,7 @@ export class NVDA implements IScreenReader {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
-    return this.#client.enqueueAndTap(
+    await this.#client.enqueueAndTap(
       () => this.#client.sendKeyCode(keyCodeCommands.moveToNext),
       options,
     );
@@ -572,7 +573,7 @@ export class NVDA implements IScreenReader {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
-    return this.#client.enqueueAndTap(
+    await this.#client.enqueueAndTap(
       () => this.#client.sendKeyCode(keyCodeCommands.activate),
       options,
     );
@@ -733,7 +734,7 @@ export class NVDA implements IScreenReader {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
-    return this.#client.enqueueAndTap(
+    await this.#client.enqueueAndTap(
       () => this.#client.sendKeyCode(command),
       options,
     );
@@ -1034,5 +1035,27 @@ export class NVDA implements IScreenReader {
    */
   getSetting(key: string): unknown {
     return getConfigKey(key);
+  }
+
+  /**
+   * Capture NVDA output produced by an action.
+   *
+   * The action can be performed using an external automation tool such as
+   * Playwright. Guidepup captures the NVDA output associated with
+   * the action and returns it together with the action's result.
+   *
+   * @param {() => Promise<T>} action The action to perform while capturing NVDA output.
+   * @param {object} [options] Additional options.
+   * @returns {Promise<Capture<T>>} The action's result and captured NVDA output.
+   */
+  async capture<T>(
+    action: () => Promise<T> | T,
+    options?: CommandOptions,
+  ): Promise<Capture<T>> {
+    if (!this.#started || this.#stopping) {
+      throw new Error(ERR_NVDA_NOT_RUNNING);
+    }
+
+    return await this.#client.enqueueAndTap(async () => action(), options);
   }
 }

--- a/src/windows/NVDA/NVDAClient.test.ts
+++ b/src/windows/NVDA/NVDAClient.test.ts
@@ -627,8 +627,16 @@ describe("NVDAClient", () => {
 
       const [r1, r2] = await Promise.all([promise1, promise2]);
 
-      expect(r1).toBe(result1);
-      expect(r2).toBe(result2);
+      expect(r1).toEqual({
+        itemText: "first phrase",
+        result: result1,
+        spokenPhrase: "first phrase",
+      });
+      expect(r2).toEqual({
+        itemText: "second phrase",
+        result: result2,
+        spokenPhrase: "second phrase",
+      });
 
       expect(await client.spokenPhraseLog()).toEqual([
         "first phrase",
@@ -706,7 +714,11 @@ describe("NVDAClient", () => {
       await expect(failPromise).rejects.toBe(testError);
       const result = await successPromise;
 
-      expect(result).toBe(successResult);
+      expect(result).toEqual({
+        itemText: "success phrase",
+        result: successResult,
+        spokenPhrase: "success phrase",
+      });
 
       expect(await client.spokenPhraseLog()).toEqual(["success phrase"]);
     });

--- a/src/windows/NVDA/NVDAClient.ts
+++ b/src/windows/NVDA/NVDAClient.ts
@@ -7,6 +7,7 @@ import {
 } from "../errors";
 import { existsSync, readFileSync } from "node:fs";
 import { NVDA_HOST, NVDA_PORT } from "./constants";
+import type { Capture } from "../../Capture";
 import { CommandOptions } from "../../CommandOptions";
 import { DEFAULT_CAPTURE } from "../../constants";
 import { delay } from "../../delay";
@@ -311,14 +312,14 @@ export class NVDAClient extends EventEmitter {
   enqueueAndTap<T>(
     action: () => Promise<T>,
     options?: ActionOptions,
-  ): Promise<T> {
+  ): Promise<Capture<T>> {
     if (this.#stopped) {
       throw new Error(ERR_NVDA_NOT_RUNNING);
     }
 
     let resolve, reject;
 
-    const promise = new Promise<T>((_resolve, _reject) => {
+    const promise = new Promise<Capture<T>>((_resolve, _reject) => {
       resolve = _resolve;
       reject = _reject;
     });
@@ -397,9 +398,15 @@ export class NVDAClient extends EventEmitter {
         result = await action();
       }
 
-      this.#spokenPhrases.push(spokenPhrases.join(". "));
+      const spokenPhrase = spokenPhrases.join(". ");
 
-      resolve(result);
+      this.#spokenPhrases.push(spokenPhrase);
+
+      resolve({
+        itemText: spokenPhrase ?? "",
+        result,
+        spokenPhrase: spokenPhrase ?? "",
+      });
     } catch (error) {
       reject(error);
     } finally {


### PR DESCRIPTION
# Issue

No issue.

## Details

Adds a new capture() API for capturing screen reader output produced by arbitrary actions.

This enables integration with external automation tools such as Playwright, allowing Guidepup to associate spoken phrases and item text with interactions performed outside of the Guidepup API. The action’s result is returned alongside the captured screen reader output.

Example:

```ts
const capture = await screenReader.capture(() =>
  page.getByRole("button", { name: "Add to cart" }).click(),
);

expect(capture.spokenPhrase).toContain("Added to cart");
```

## CheckList

- [x] Has been tested (where required).
