### PR TITLE
feat: teardown running screen readers on process exit/interrupt/etc.

### DIFF
--- a/.github/workflows/playwright-nvda.yml
+++ b/.github/workflows/playwright-nvda.yml
@@ -22,11 +22,11 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-      - run: npx -y @guidepup/setup@0.24.1 setup --ci
+      - run: npx -y --min-release-age=0 @guidepup/setup@0.24.5 setup --ci
       - run: npm ci --no-audit --no-fund --no-progress
       - run: npm ci --prefix ./examples/playwright-nvda --no-audit --no-fund --no-progress
       - run: npm --prefix ./examples/playwright-nvda rebuild ffmpeg-static --ignore-scripts=false
-      - run: npx -y @guidepup/setup@0.24.1 install
+      - run: npx -y --min-release-age=0 @guidepup/setup@0.24.5 install
       - run: npm --prefix ./examples/playwright-nvda run browsers
       - run: npm --prefix ./examples/playwright-nvda run test:${{ matrix.browser }}
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright-screenreader.yml
+++ b/.github/workflows/playwright-screenreader.yml
@@ -22,12 +22,12 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-      - run: npx -y @guidepup/setup@0.24.1 setup --ci --macos-record
+      - run: npx -y --min-release-age=0 @guidepup/setup@0.24.5 setup --ci --macos-record
       - run: npm ci --no-audit --no-fund --no-progress
       - run: npm ci --prefix ./examples/playwright-screenreader --no-audit --no-fund --no-progress
       - run: npm --prefix ./examples/playwright-screenreader rebuild ffmpeg-static --ignore-scripts=false
       - run: npm --prefix ./examples/playwright-screenreader run browsers
-      - run: npx -y @guidepup/setup@0.24.1 install
+      - run: npx -y --min-release-age=0 @guidepup/setup@0.24.5 install
       - run: npm --prefix ./examples/playwright-screenreader run test:${{ matrix.browser }}
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/playwright-voiceover.yml
+++ b/.github/workflows/playwright-voiceover.yml
@@ -22,12 +22,12 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-      - run: npx -y @guidepup/setup@0.24.1 setup --ci --macos-record
+      - run: npx -y --min-release-age=0 @guidepup/setup@0.24.5 setup --ci --macos-record
       - run: npm ci --no-audit --no-fund --no-progress
       - run: npm ci --prefix ./examples/playwright-voiceover --no-audit --no-fund --no-progress
       - run: npm --prefix ./examples/playwright-voiceover rebuild ffmpeg-static --ignore-scripts=false
       - run: npm --prefix ./examples/playwright-voiceover run browsers
-      - run: npx -y @guidepup/setup@0.24.1 install
+      - run: npx -y --min-release-age=0 @guidepup/setup@0.24.5 install
       - run: npm --prefix ./examples/playwright-voiceover run test:${{ matrix.browser }}
       - uses: actions/upload-artifact@v4
         if: always()

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,8 @@ module.exports = {
     // TODO: coverage needed for ScreenReader
     "<rootDir>/src/ScreenReader.ts",
     "<rootDir>/src/StartOptions.ts",
+    // TODO: coverage needed for teardown
+    "<rootDir>/src/teardown.ts",
     "<rootDir>/src/macOS/Applications.ts",
     "<rootDir>/src/macOS/KeyboardCommand.ts",
     "<rootDir>/src/macOS/KeyCodeCommand.ts",

--- a/src/macOS/VoiceOver/VoiceOver.test.ts
+++ b/src/macOS/VoiceOver/VoiceOver.test.ts
@@ -1,3 +1,4 @@
+import { addTeardownHandler, removeTeardownHandler } from "../../teardown";
 import {
   ERR_MACOS_VERSION_NOT_SUPPORTED,
   ERR_VOICE_OVER_ALREADY_RUNNING,
@@ -42,6 +43,10 @@ jest.mock("../../../manifest.json", () => ({
       ],
     },
   ],
+}));
+jest.mock("../../teardown", () => ({
+  addTeardownHandler: jest.fn(),
+  removeTeardownHandler: jest.fn(),
 }));
 jest.mock("node:os", () => ({
   release: jest.fn(),
@@ -287,11 +292,11 @@ describe("VoiceOver", () => {
           }
         });
 
-        test("should throw an error trying to access the keyboard commands getter", () => {
+        it("should throw an error trying to access the keyboard commands getter", () => {
           expect(() => vo.keyboardCommands).toThrow(ERR_VOICE_OVER_NOT_RUNNING);
         });
 
-        test("should throw an error trying to access the commander commands getter", () => {
+        it("should throw an error trying to access the commander commands getter", () => {
           expect(() => vo.commanderCommands).toThrow(
             ERR_VOICE_OVER_NOT_RUNNING,
           );
@@ -318,6 +323,10 @@ describe("VoiceOver", () => {
       `("when called $description", ({ options }) => {
         beforeEach(async () => {
           await vo.start(options);
+        });
+
+        it("should add a teardown handler to terminate VoiceOver if the process terminates without graceful user stop", () => {
+          expect(addTeardownHandler).toHaveBeenCalled();
         });
 
         it("should construct a VoiceOver Client instance", () => {
@@ -363,6 +372,25 @@ describe("VoiceOver", () => {
         it("should wait for VoiceOver to be running", () => {
           expect(waitForRunning).toHaveBeenCalledWith(options);
         });
+
+        describe("when the process is terminated and the teardown is triggered", () => {
+          beforeEach(async () => {
+            await jest.mocked(addTeardownHandler).mock.calls[0][0]();
+          });
+
+          it("should remove the teardown handler", () => {
+            expect(removeTeardownHandler).toHaveBeenCalled();
+          });
+
+          it("should attempt to terminate the process", () => {
+            expect(terminateVoiceOverProcess).toHaveBeenCalled();
+            expect(waitForNotRunning).toHaveBeenCalled();
+          });
+
+          it("should attempt to unmount the Guidepup preferences", () => {
+            expect(unmountGuidepupPreferences).toHaveBeenCalled();
+          });
+        });
       });
 
       describe("when called with custom settings", () => {
@@ -391,13 +419,13 @@ describe("VoiceOver", () => {
           }
         });
 
-        test("should retry from a clean VoiceOver process", () => {
+        it("should retry from a clean VoiceOver process", () => {
           expect(start).toHaveBeenCalledTimes(2);
-          expect(terminateVoiceOverProcess).toHaveBeenCalledTimes(3);
-          expect(waitForNotRunning).toHaveBeenCalledTimes(2);
+          expect(terminateVoiceOverProcess).toHaveBeenCalledTimes(2 + 2);
+          expect(waitForNotRunning).toHaveBeenCalledTimes(2 + 2);
         });
 
-        test("should return a stable startup error with the readiness failure as its cause", () => {
+        it("should return a stable startup error with the readiness failure as its cause", () => {
           expect(thrownError).toEqual(
             new Error(ERR_VOICE_OVER_CANNOT_BE_STARTED, {
               cause: startupError,
@@ -405,7 +433,44 @@ describe("VoiceOver", () => {
           );
         });
 
-        test("should unmount Guidepup preferences after failing", () => {
+        it("should remove the teardown handler", () => {
+          expect(removeTeardownHandler).toHaveBeenCalled();
+        });
+
+        it("should unmount Guidepup preferences after failing", () => {
+          expect(unmountGuidepupPreferences).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      describe("when VoiceOver is already running from outside of Guidepup and fails to terminate VoiceOver after several attempts", () => {
+        const terminationErrorStub = new Error("test-termination-error");
+        let thrownError: Error;
+
+        beforeEach(async () => {
+          jest
+            .mocked(terminateVoiceOverProcess)
+            .mockRejectedValue(terminationErrorStub);
+
+          try {
+            await vo.start();
+          } catch (error) {
+            thrownError = error as Error;
+          }
+        });
+
+        it("should throw an error", () => {
+          expect(thrownError).toEqual(
+            new Error(ERR_VOICE_OVER_CANNOT_BE_STARTED, {
+              cause: terminationErrorStub,
+            }),
+          );
+        });
+
+        it("should remove the teardown handler", () => {
+          expect(removeTeardownHandler).toHaveBeenCalled();
+        });
+
+        it("should unmount Guidepup preferences after failing", () => {
           expect(unmountGuidepupPreferences).toHaveBeenCalledTimes(1);
         });
       });
@@ -496,12 +561,42 @@ describe("VoiceOver", () => {
         expect(unmountGuidepupPreferences).toHaveBeenCalled();
       });
 
+      it("should remove the teardown handler", () => {
+        expect(removeTeardownHandler).toHaveBeenCalled();
+      });
+
       describe("when called again and start hasn't been called this time", () => {
         it("should throw an error", async () => {
           await expect(async () => await vo.stop(options)).rejects.toThrow(
             ERR_VOICE_OVER_NOT_RUNNING,
           );
         });
+      });
+    });
+
+    describe("when fails to terminate VoiceOver after several attempts", () => {
+      const terminationErrorStub = new Error("test-termination-error");
+
+      beforeEach(async () => {
+        jest.mocked(isMacOS).mockReturnValue(true);
+
+        await vo.start();
+
+        jest.clearAllMocks();
+
+        jest
+          .mocked(terminateVoiceOverProcess)
+          .mockRejectedValue(terminationErrorStub);
+      });
+
+      it("should throw an error", async () => {
+        await expect(async () => await vo.stop()).rejects.toThrow(
+          terminationErrorStub,
+        );
+      });
+
+      it("should not remove the teardown handler so it tries to teardown again on exit", () => {
+        expect(removeTeardownHandler).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/macOS/VoiceOver/VoiceOver.ts
+++ b/src/macOS/VoiceOver/VoiceOver.ts
@@ -1,3 +1,4 @@
+import { addTeardownHandler, removeTeardownHandler } from "../../teardown";
 import {
   ERR_MACOS_VERSION_NOT_SUPPORTED,
   ERR_VOICE_OVER_ALREADY_RUNNING,
@@ -49,6 +50,10 @@ export class VoiceOver implements IScreenReader {
    * Number of clean-start attempts before reporting a startup failure.
    */
   static readonly #START_ATTEMPTS = 2;
+  /**
+   * Number of attempts before reporting a stop failure.
+   */
+  static readonly #STOP_ATTEMPTS = 2;
 
   /**
    * VoiceOver running status.
@@ -94,6 +99,48 @@ export class VoiceOver implements IScreenReader {
    * VoiceOver mouse APIs.
    */
   #mouse!: VoiceOverMouse;
+
+  /**
+   * Attempt to stop VoiceOver and teardown preferences when the process is terminating.
+   */
+  #teardownAfterTermination = async (): Promise<void> => {
+    for (let attempt = 0; attempt < VoiceOver.#STOP_ATTEMPTS; attempt++) {
+      try {
+        await terminateVoiceOverProcess();
+        await waitForNotRunning();
+
+        break;
+      } catch {
+        // Best effort only.
+      }
+    }
+
+    try {
+      unmountGuidepupPreferences();
+    } catch {
+      // Best effort only.
+    }
+
+    this.#client = null;
+    this.#caption = null;
+    this.#commander = null;
+    this.#cursor = null;
+    this.#keyboard = null;
+    this.#mouse = null;
+
+    this.#started = false;
+    this.#starting = false;
+    this.#stopping = false;
+  };
+
+  /**
+   * Handler for teardown should the process be interrupted, killed, etc.
+   */
+  #teardownHandler = async (): Promise<void> => {
+    removeTeardownHandler(this.#teardownHandler);
+
+    await this.#teardownAfterTermination();
+  };
 
   /**
    * The screen reader name.
@@ -307,6 +354,7 @@ export class VoiceOver implements IScreenReader {
    *
    * @param {object} [options] Additional options.
    */
+
   async start(options?: StartOptions): Promise<void> {
     if (!this.detect()) {
       throw new Error(ERR_VOICE_OVER_NOT_SUPPORTED);
@@ -318,7 +366,22 @@ export class VoiceOver implements IScreenReader {
 
     this.#starting = true;
 
+    addTeardownHandler(this.#teardownHandler);
+
     try {
+      for (let attempt = 0; attempt < VoiceOver.#STOP_ATTEMPTS; attempt++) {
+        try {
+          await terminateVoiceOverProcess(options);
+          await waitForNotRunning(options);
+
+          break;
+        } catch (error) {
+          if (attempt === VoiceOver.#STOP_ATTEMPTS - 1) {
+            throw error;
+          }
+        }
+      }
+
       mountGuidepupPreferences();
 
       if (options?.settings) {
@@ -348,17 +411,7 @@ export class VoiceOver implements IScreenReader {
       this.#starting = false;
 
       if (!this.#started) {
-        try {
-          await terminateVoiceOverProcess(options);
-        } catch {
-          // Swallow
-        }
-
-        try {
-          unmountGuidepupPreferences();
-        } catch {
-          // Swallow
-        }
+        await this.#teardownHandler();
       }
     }
 
@@ -398,21 +451,32 @@ export class VoiceOver implements IScreenReader {
 
     this.#stopping = true;
 
-    await this.#client.stop();
-
-    this.#client = null;
-    this.#caption = null;
-    this.#commander = null;
-    this.#cursor = null;
-    this.#keyboard = null;
-    this.#mouse = null;
-
-    unmountGuidepupPreferences();
-
-    await terminateVoiceOverProcess(options);
-
     try {
-      await waitForNotRunning(options);
+      await this.#client.stop();
+
+      this.#client = null;
+      this.#caption = null;
+      this.#commander = null;
+      this.#cursor = null;
+      this.#keyboard = null;
+      this.#mouse = null;
+
+      for (let attempt = 0; attempt < VoiceOver.#STOP_ATTEMPTS; attempt++) {
+        try {
+          await terminateVoiceOverProcess(options);
+          await waitForNotRunning(options);
+
+          break;
+        } catch (error) {
+          if (attempt === VoiceOver.#STOP_ATTEMPTS - 1) {
+            throw error;
+          }
+        }
+      }
+
+      unmountGuidepupPreferences();
+
+      removeTeardownHandler(this.#teardownHandler);
     } finally {
       this.#started = false;
       this.#stopping = false;

--- a/src/teardown.ts
+++ b/src/teardown.ts
@@ -1,0 +1,41 @@
+const teardownHandlers = new Set<() => Promise<void>>();
+
+let processHandlersInstalled = false;
+
+async function teardownAll(): Promise<void> {
+  await Promise.all(
+    [...teardownHandlers].map((teardown) => teardown().catch(() => {})),
+  );
+}
+
+function signalHandler(): void {
+  void teardownAll();
+}
+
+export function addTeardownHandler(handler: () => Promise<void>): void {
+  teardownHandlers.add(handler);
+
+  if (teardownHandlers.size === 1) {
+    processHandlersInstalled = true;
+
+    process.on("SIGINT", signalHandler);
+    process.on("SIGTERM", signalHandler);
+    process.on("SIGQUIT", signalHandler);
+    process.on("SIGHUP", signalHandler);
+    process.on("beforeExit", signalHandler);
+  }
+}
+
+export function removeTeardownHandler(handler: () => Promise<void>): void {
+  teardownHandlers.delete(handler);
+
+  if (teardownHandlers.size === 0 && processHandlersInstalled) {
+    processHandlersInstalled = false;
+
+    process.off("SIGINT", signalHandler);
+    process.off("SIGTERM", signalHandler);
+    process.off("SIGQUIT", signalHandler);
+    process.off("SIGHUP", signalHandler);
+    process.off("beforeExit", signalHandler);
+  }
+}

--- a/src/windows/NVDA/NVDA.ts
+++ b/src/windows/NVDA/NVDA.ts
@@ -1,3 +1,4 @@
+import { addTeardownHandler, removeTeardownHandler } from "../../teardown";
 import {
   createGuidepupConfig,
   deleteGuidepupConfig,
@@ -59,6 +60,44 @@ export class NVDA implements IScreenReader {
    * NVDA stopping status.
    */
   #stopping = false;
+
+  /**
+   * Attempt to stop NVD and teardown config when the process is terminating.
+   */
+  #teardownAfterTermination = async (): Promise<void> => {
+    try {
+      await this.#client.stop();
+    } catch {
+      // Best effort only.
+    }
+
+    this.#client = null;
+
+    try {
+      quit();
+    } catch {
+      // Best effort only.
+    }
+
+    try {
+      deleteGuidepupConfig();
+    } catch {
+      // Best effort only.
+    }
+
+    this.#started = false;
+    this.#starting = false;
+    this.#stopping = false;
+  };
+
+  /**
+   * Handler for teardown should the process be interrupted, killed, etc.
+   */
+  #teardownHandler = async (): Promise<void> => {
+    removeTeardownHandler(this.#teardownHandler);
+
+    await this.#teardownAfterTermination();
+  };
 
   /**
    * The screen reader name.
@@ -228,7 +267,11 @@ export class NVDA implements IScreenReader {
 
     this.#starting = true;
 
+    addTeardownHandler(this.#teardownHandler);
+
     try {
+      quit();
+
       createGuidepupConfig();
 
       if (options?.settings) {
@@ -247,25 +290,7 @@ export class NVDA implements IScreenReader {
       this.#starting = false;
 
       if (!this.#started) {
-        try {
-          await this.#client.stop();
-        } catch {
-          // Swallow
-        }
-
-        this.#client = null;
-
-        try {
-          quit();
-        } catch {
-          // Swallow
-        }
-
-        try {
-          deleteGuidepupConfig();
-        } catch {
-          // Swallow
-        }
+        await this.#teardownHandler();
       }
     }
   }
@@ -294,13 +319,20 @@ export class NVDA implements IScreenReader {
 
     this.#stopping = true;
 
-    await this.#client.stop();
-    this.#client = null;
+    try {
+      await this.#client.stop();
 
-    quit();
+      this.#client = null;
 
-    this.#started = false;
-    this.#stopping = false;
+      quit();
+
+      deleteGuidepupConfig();
+
+      removeTeardownHandler(this.#teardownHandler);
+    } finally {
+      this.#started = false;
+      this.#stopping = false;
+    }
   }
 
   /**


### PR DESCRIPTION
# Issue

Works towards #137

## Details

Introduces process handlers for SIGINT, beforeExit etc. that are lazily added on `start()` calls, and removed on successful `stop()`. These handlers perform a best effort teardown of the screen reader and settings to combat errors resulting in missed teardown which can leave a screen reader running after the Node process has finished.

Also introduces additional teardown logic on `start()` to improve the idempotency.

## CheckList

- [ ] Has been tested (where required).
